### PR TITLE
feat: Implement agent persona loading and MCP server registry

### DIFF
--- a/SharpClaw.Cli/Program.cs
+++ b/SharpClaw.Cli/Program.cs
@@ -2,6 +2,23 @@
 using ModelContextProtocol.Client;
 using SharpClaw.Core;
 
+// ── Parse CLI arguments ──────────────────────────────────────────────────────
+
+if (args.Length < 1)
+{
+    Console.Error.WriteLine("Usage: SharpClaw.Cli <path-to-agent.md> [user-prompt]");
+    return 1;
+}
+
+var agentFilePath = args[0];
+if (!File.Exists(agentFilePath))
+{
+    Console.Error.WriteLine($"Error: Agent file not found: {agentFilePath}");
+    return 1;
+}
+
+var userPrompt = args.Length >= 2 ? args[1] : "Hello";
+
 // ── Configuration ────────────────────────────────────────────────────────────
 
 var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
@@ -11,49 +28,57 @@ if (string.IsNullOrWhiteSpace(apiKey))
     return 1;
 }
 
-// ── Connect to the MCP filesystem server ─────────────────────────────────────
-// The server is launched as a child process via npx.
-// We expose /tmp so Claude can list its contents.
+// ── Load persona ─────────────────────────────────────────────────────────────
 
-Console.WriteLine("Connecting to MCP filesystem server…");
+var persona = AgentPersonaLoader.Load(agentFilePath);
+Console.WriteLine($"Loaded agent: {persona.Name}");
+Console.WriteLine($"MCP servers:  {string.Join(", ", persona.McpServers)}");
 
-var transport = new StdioClientTransport(new StdioClientTransportOptions
+// ── Connect to MCP servers listed in the persona ─────────────────────────────
+
+var mcpClients = new List<McpClient>();
+var allTools = new List<Anthropic.Models.Messages.ToolUnion>();
+
+// Map from tool name → which MCP client owns it, for dispatching calls.
+var toolClientMap = new Dictionary<string, McpClient>();
+
+try
 {
-    Command = "npx",
-    Arguments = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
-    Name = "filesystem",
-});
+    foreach (var serverName in persona.McpServers)
+    {
+        Console.WriteLine($"Connecting to MCP server '{serverName}'…");
+        var transport = McpServerRegistry.Resolve(serverName);
+        var client = await McpClient.CreateAsync(transport);
+        mcpClients.Add(client);
 
-await using var mcpClient = await McpClient.CreateAsync(transport);
+        var tools = await client.ListToolsAsync();
+        Console.WriteLine($"  Discovered {tools.Count} tool(s):");
+        foreach (var t in tools)
+        {
+            Console.WriteLine($"    • {t.Name} — {t.Description}");
+            allTools.Add(MessageLoop.ToAnthropicTool(t));
+            toolClientMap[t.Name] = client;
+        }
+    }
 
-// ── Discover tools ───────────────────────────────────────────────────────────
+    // ── Run the agent loop ───────────────────────────────────────────────────
 
-var mcpTools = await mcpClient.ListToolsAsync();
-Console.WriteLine($"Discovered {mcpTools.Count} MCP tool(s):");
-foreach (var t in mcpTools)
-    Console.WriteLine($"  • {t.Name} — {t.Description}");
+    using var anthropic = new AnthropicClient(new Anthropic.Core.ClientOptions { ApiKey = apiKey });
+    var loop = new MessageLoop(anthropic);
 
-var anthropicTools = mcpTools.Select(MessageLoop.ToAnthropicTool).ToList();
+    Console.WriteLine($"\nUser: {userPrompt}\n");
 
-// ── Run the agent loop ───────────────────────────────────────────────────────
+    var answer = await loop.RunAsync(
+        systemPrompt: persona.SystemPrompt,
+        tools: allTools,
+        userMessage: userPrompt,
+        toolClientMap: toolClientMap);
 
-using var anthropic = new AnthropicClient(new Anthropic.Core.ClientOptions { ApiKey = apiKey });
-var loop = new MessageLoop(anthropic);
-
-const string SystemPrompt =
-    "You are a helpful assistant with access to the local filesystem. " +
-    "When asked about files, use the available tools to retrieve real information.";
-
-const string UserPrompt = "List the files in /tmp";
-
-Console.WriteLine($"\nUser: {UserPrompt}\n");
-
-var answer = await loop.RunAsync(
-    systemPrompt: SystemPrompt,
-    tools: anthropicTools,
-    userMessage: UserPrompt,
-    mcpClient: mcpClient);
-
-Console.WriteLine($"Assistant: {answer}");
-
-return 0;
+    Console.WriteLine($"Assistant: {answer}");
+    return 0;
+}
+finally
+{
+    foreach (var client in mcpClients)
+        await client.DisposeAsync();
+}

--- a/SharpClaw.Core/AgentPersona.cs
+++ b/SharpClaw.Core/AgentPersona.cs
@@ -1,0 +1,9 @@
+namespace SharpClaw.Core;
+
+/// <summary>
+/// Describes an agent's identity and capabilities, loaded from an .agent.md file.
+/// </summary>
+public sealed record AgentPersona(
+    string Name,
+    string SystemPrompt,
+    IReadOnlyList<string> McpServers);

--- a/SharpClaw.Core/AgentPersonaLoader.cs
+++ b/SharpClaw.Core/AgentPersonaLoader.cs
@@ -1,0 +1,118 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SharpClaw.Core;
+
+/// <summary>
+/// Reads an .agent.md file (YAML frontmatter + markdown body) and produces an <see cref="AgentPersona"/>.
+/// </summary>
+public static class AgentPersonaLoader
+{
+    private const string FrontmatterDelimiter = "---";
+
+    /// <summary>
+    /// Loads an <see cref="AgentPersona"/> from the given .agent.md file path.
+    /// </summary>
+    public static AgentPersona Load(string filePath)
+    {
+        var text = File.ReadAllText(filePath);
+        return Parse(text);
+    }
+
+    /// <summary>
+    /// Parses raw .agent.md content into an <see cref="AgentPersona"/>.
+    /// </summary>
+    public static AgentPersona Parse(string content)
+    {
+        var (yaml, body) = SplitFrontmatter(content);
+
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var frontmatter = deserializer.Deserialize<Frontmatter>(yaml) ?? new Frontmatter();
+
+        return new AgentPersona(
+            Name: frontmatter.Name ?? Path.GetFileNameWithoutExtension("agent"),
+            SystemPrompt: body.Trim(),
+            McpServers: frontmatter.McpServers ?? []);
+    }
+
+    private static (string Yaml, string Body) SplitFrontmatter(string content)
+    {
+        var span = content.AsSpan().TrimStart();
+
+        if (!span.StartsWith(FrontmatterDelimiter))
+            return (string.Empty, content);
+
+        // Skip past the opening "---" line.
+        var afterOpen = span[FrontmatterDelimiter.Length..];
+        var newline = afterOpen.IndexOfAny('\r', '\n');
+        if (newline < 0)
+            return (string.Empty, content);
+
+        // Skip \r\n or \n
+        if (newline < afterOpen.Length - 1 && afterOpen[newline] == '\r' && afterOpen[newline + 1] == '\n')
+            newline += 2;
+        else
+            newline += 1;
+
+        var rest = afterOpen[newline..];
+
+        // Find the closing "---"
+        var closeIdx = IndexOfLine(rest, FrontmatterDelimiter);
+        if (closeIdx < 0)
+            return (string.Empty, content);
+
+        var yaml = rest[..closeIdx].ToString();
+
+        var afterClose = rest[(closeIdx + FrontmatterDelimiter.Length)..];
+        // Skip past the closing delimiter line.
+        var bodyStart = afterClose.IndexOfAny('\r', '\n');
+        string body;
+        if (bodyStart < 0)
+            body = string.Empty;
+        else
+        {
+            if (bodyStart < afterClose.Length - 1 && afterClose[bodyStart] == '\r' && afterClose[bodyStart + 1] == '\n')
+                bodyStart += 2;
+            else
+                bodyStart += 1;
+            body = afterClose[bodyStart..].ToString();
+        }
+
+        return (yaml, body);
+    }
+
+    /// <summary>
+    /// Returns the char index where a line consisting solely of <paramref name="marker"/> begins.
+    /// </summary>
+    private static int IndexOfLine(ReadOnlySpan<char> text, string marker)
+    {
+        var idx = 0;
+        while (idx < text.Length)
+        {
+            var lineEnd = text[idx..].IndexOfAny('\r', '\n');
+            var line = lineEnd < 0 ? text[idx..] : text[idx..(idx + lineEnd)];
+
+            if (line.SequenceEqual(marker.AsSpan()))
+                return idx;
+
+            if (lineEnd < 0)
+                break;
+
+            idx += lineEnd;
+            if (idx < text.Length && text[idx] == '\r') idx++;
+            if (idx < text.Length && text[idx] == '\n') idx++;
+        }
+
+        return -1;
+    }
+
+    private sealed class Frontmatter
+    {
+        public string? Name { get; set; }
+        public List<string>? McpServers { get; set; }
+    }
+}

--- a/SharpClaw.Core/McpServerRegistry.cs
+++ b/SharpClaw.Core/McpServerRegistry.cs
@@ -1,0 +1,30 @@
+using ModelContextProtocol.Client;
+
+namespace SharpClaw.Core;
+
+/// <summary>
+/// Maps well-known MCP server names to their transport configurations.
+/// Add entries here for every server that agents can reference by name.
+/// </summary>
+public static class McpServerRegistry
+{
+    /// <summary>
+    /// Returns an <see cref="IClientTransport"/> for a well-known server name.
+    /// </summary>
+    public static IClientTransport Resolve(string serverName) => serverName switch
+    {
+        "filesystem" => new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = "npx",
+            Arguments = ["-y", "@modelcontextprotocol/server-filesystem", "/home/khughes"],
+            Name = "filesystem",
+        }),
+        "sqlite" => new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = "npx",
+            Arguments = ["-y", "@anthropic/mcp-server-sqlite"],
+            Name = "sqlite",
+        }),
+        _ => throw new ArgumentException($"Unknown MCP server: '{serverName}'. Register it in McpServerRegistry."),
+    };
+}

--- a/SharpClaw.Core/MessageLoop.cs
+++ b/SharpClaw.Core/MessageLoop.cs
@@ -20,7 +20,7 @@ public sealed class MessageLoop
     private static readonly JsonElement _objectTypeElement =
         JsonDocument.Parse("\"object\"").RootElement.Clone();
 
-    public MessageLoop(AnthropicClient anthropic, string model = "claude-3-5-haiku-20241022")
+    public MessageLoop(AnthropicClient anthropic, string model = "claude-haiku-4-5-20251001")
     {
         _anthropic = anthropic;
         _model = model;
@@ -32,14 +32,14 @@ public sealed class MessageLoop
     /// <param name="systemPrompt">System prompt to send on every turn.</param>
     /// <param name="tools">Anthropic tool schemas to expose to Claude.</param>
     /// <param name="userMessage">Initial user message.</param>
-    /// <param name="mcpClient">MCP client used to execute tool calls.</param>
+    /// <param name="toolClientMap">Maps tool names to the MCP client that owns them.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Claude's final text response.</returns>
     public async Task<string> RunAsync(
         string systemPrompt,
         IReadOnlyList<Anthropic.Models.Messages.ToolUnion> tools,
         string userMessage,
-        McpClient mcpClient,
+        IReadOnlyDictionary<string, McpClient> toolClientMap,
         CancellationToken cancellationToken = default)
     {
         var messages = new List<Anthropic.Models.Messages.MessageParam>
@@ -90,6 +90,9 @@ public sealed class MessageLoop
             {
                 if (!block.TryPickToolUse(out var toolUse))
                     continue;
+
+                if (!toolClientMap.TryGetValue(toolUse.Name, out var mcpClient))
+                    throw new InvalidOperationException($"No MCP client registered for tool '{toolUse.Name}'.");
 
                 // Adapt IReadOnlyDictionary<string, JsonElement> → IReadOnlyDictionary<string, object?>
                 // without copying: forward the original dict through a lightweight adapter.

--- a/SharpClaw.Core/SharpClaw.Core.csproj
+++ b/SharpClaw.Core/SharpClaw.Core.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Anthropic" Version="12.9.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
 </Project>

--- a/agents/file-browser.agent.md
+++ b/agents/file-browser.agent.md
@@ -1,0 +1,7 @@
+---
+name: FileBrowser
+mcp_servers:
+  - filesystem
+---
+You are a helpful file browser assistant. You can list, read, and search files
+on the local filesystem. Answer questions about file contents concisely.

--- a/agents/home-assistant.agent.md
+++ b/agents/home-assistant.agent.md
@@ -1,0 +1,8 @@
+---
+name: HomeAssistant
+mcp_servers:
+  - filesystem
+---
+You are a home lab automation agent with access to the local filesystem.
+When asked about files, use the available tools to retrieve real information.
+Help the user manage their home automation configuration files.


### PR DESCRIPTION
- Added AgentPersona and AgentPersonaLoader to manage agent identities and capabilities.
- Introduced McpServerRegistry for mapping MCP server names to transport configurations.
- Updated MessageLoop to support dynamic tool client mapping.
- Enhanced CLI argument parsing for agent file paths and user prompts.
- Added example agent definitions for FileBrowser and HomeAssistant.
- Included YamlDotNet package for YAML parsing.