### PR TITLE
feat: better handling of env var creds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+POSTGRES_DB=sharpclaw
+POSTGRES_USER=sharpclaw
+POSTGRES_PASSWORD=change-me
+SHARPCLAW_DB_CONNECTION=Host=localhost;Database=sharpclaw;Username=sharpclaw;Password=change-me
+
 ANTHROPIC_API_KEY=
 GITHUB_COPILOT_TOKEN=
 SHARPCLAW_API_KEY=

--- a/README.md
+++ b/README.md
@@ -176,11 +176,14 @@ Older flat permission rules are migrated on startup to MCP-scoped patterns when 
 
 | Variable | Purpose |
 |---|---|
+| `POSTGRES_DB` | Required PostgreSQL database name for the Docker Compose stack |
+| `POSTGRES_USER` | Required PostgreSQL username for the Docker Compose stack and API container |
+| `POSTGRES_PASSWORD` | Required PostgreSQL password for the Docker Compose stack and API container |
 | `ANTHROPIC_API_KEY` | Required for Anthropic-backed agents |
 | `GITHUB_COPILOT_TOKEN` | Copilot auth token used by the GitHub Copilot backend |
 | `GITHUB_TOKEN` | Alternate token source checked by the Copilot backend |
 | `SHARPCLAW_API_KEY` | Optional API key enforced on `/api/*` routes except SSE streams |
-| `SHARPCLAW_DB_CONNECTION` | Optional PostgreSQL connection string override |
+| `SHARPCLAW_DB_CONNECTION` | Required for non-Docker API runs unless `ConnectionStrings:DefaultConnection` is supplied another way |
 | `SHARPCLAW_WORKSPACE` | Workspace path used by the backend and filesystem MCP tooling |
 | `MCP_ALLOWED_DIRS` | Colon-delimited allowed directories for filesystem MCP access when `SHARPCLAW_WORKSPACE` is not set |
 
@@ -189,6 +192,9 @@ Older flat permission rules are migrated on startup to MCP-scoped patterns when 
 You can use a local `.env` file with Docker Compose:
 
 ```dotenv
+POSTGRES_DB=sharpclaw
+POSTGRES_USER=sharpclaw
+POSTGRES_PASSWORD=change-me
 ANTHROPIC_API_KEY=your-anthropic-key
 GITHUB_COPILOT_TOKEN=your-copilot-token
 SHARPCLAW_API_KEY=replace-me-if-you-want-api-auth
@@ -197,6 +203,8 @@ SHARPCLAW_WORKSPACE=/absolute/path/to/your/workspace
 
 Notes:
 
+- `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` are required for Docker Compose runs and are used to configure both the PostgreSQL container and the API container's default connection string
+- Direct `dotnet run` execution also requires a database connection via `SHARPCLAW_DB_CONNECTION` or `ConnectionStrings:DefaultConnection`; the API no longer falls back to a hard-coded local database credential set
 - `ANTHROPIC_API_KEY` is required for Anthropic-backed agents
 - `GITHUB_COPILOT_TOKEN` or `GITHUB_TOKEN` is required for Copilot-backed agents
 - `SHARPCLAW_API_KEY` is optional, but recommended if you do not want an open local API
@@ -207,7 +215,7 @@ Notes:
 The API resolves configuration in this order where applicable:
 
 - API key: `ApiKey` config value, then `SHARPCLAW_API_KEY`
-- DB connection: `ConnectionStrings:DefaultConnection`, then `SHARPCLAW_DB_CONNECTION`, then a local default PostgreSQL connection string
+- DB connection: `ConnectionStrings:DefaultConnection`, then `SHARPCLAW_DB_CONNECTION`
 - Workspace: `SHARPCLAW_WORKSPACE`, then current working directory
 
 ## Running the Project

--- a/SharpClaw.Api/Program.cs
+++ b/SharpClaw.Api/Program.cs
@@ -19,8 +19,14 @@ var expectedApiKey = app.Configuration["ApiKey"]
 // ── Session store (PostgreSQL) ───────────────────────────────────────────────
 
 var connectionString = app.Configuration.GetConnectionString("DefaultConnection")
-    ?? Environment.GetEnvironmentVariable("SHARPCLAW_DB_CONNECTION")
-    ?? "Host=localhost;Database=sharpclaw;Username=sharpclaw;Password=sharpclaw";
+    ?? Environment.GetEnvironmentVariable("SHARPCLAW_DB_CONNECTION");
+
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    throw new InvalidOperationException(
+        "Database connection is not configured. Set ConnectionStrings:DefaultConnection or SHARPCLAW_DB_CONNECTION. " +
+        "For Docker Compose runs, ensure POSTGRES_DB, POSTGRES_USER, and POSTGRES_PASSWORD are set.");
+}
 
 var store = new SessionStore(connectionString);
 var providerHttpClient = new HttpClient();

--- a/SharpClaw.Api/appsettings.json
+++ b/SharpClaw.Api/appsettings.json
@@ -5,8 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=sharpclaw;Username=sharpclaw;Password=sharpclaw"
-  }
+  "AllowedHosts": "*"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     container_name: sharpclaw-db
     restart: unless-stopped
     environment:
-      POSTGRES_DB: sharpclaw
-      POSTGRES_USER: sharpclaw
-      POSTGRES_PASSWORD: sharpclaw
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     volumes:
       - /home/khughes/sharpclaw/data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U sharpclaw -d sharpclaw"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:?POSTGRES_USER is required} -d ${POSTGRES_DB:?POSTGRES_DB is required}"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -27,7 +27,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - SHARPCLAW_API_KEY=${SHARPCLAW_API_KEY}
       - GITHUB_COPILOT_TOKEN=${GITHUB_COPILOT_TOKEN}
-      - ConnectionStrings__DefaultConnection=Host=postgres;Database=sharpclaw;Username=sharpclaw;Password=sharpclaw
+      - ConnectionStrings__DefaultConnection=Host=postgres;Database=${POSTGRES_DB:?POSTGRES_DB is required};Username=${POSTGRES_USER:?POSTGRES_USER is required};Password=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       - SHARPCLAW_WORKSPACE=/workspace
 
   web:


### PR DESCRIPTION
This pull request updates the database configuration approach for both Docker Compose and direct runs, making the setup more secure and explicit. It removes fallback to hard-coded local database credentials, enforces required environment variables for Docker Compose, and improves documentation for environment setup.

**Database configuration changes:**

* Removed the hard-coded default PostgreSQL connection string in `SharpClaw.Api/Program.cs`; the API now requires either `ConnectionStrings:DefaultConnection` or `SHARPCLAW_DB_CONNECTION` to be set, and throws an error if neither is provided.
* Deleted the default connection string from `appsettings.json`, requiring explicit configuration.

**Docker Compose improvements:**

* Updated `docker-compose.yml` to require `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` environment variables for both the database and API containers, removing hard-coded credentials and making the configuration explicit. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L7-R13) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L30-R30)

**Documentation updates:**

* Added `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` to `.env.example` and documented their usage and requirements in the `README.md`, clarifying the setup for both Docker and direct runs. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R179-R186) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195-R197) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R206-R207)
* Updated the `README.md` to remove references to the old fallback connection string and clarify the order of precedence for database configuration.