### PR TITLE
Refactor: Pulled all the LLM providers out to their own projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Older flat permission rules are migrated on startup to MCP-scoped patterns when 
 ├── docker-compose.yml
 ├── README.md
 ├── SharpClaw.slnx
+├── SharpClaw.Anthropic/
 ├── SharpClaw.Api/
 ├── SharpClaw.Copilot/
 ├── SharpClaw.Core/
@@ -160,6 +161,8 @@ Older flat permission rules are migrated on startup to MCP-scoped patterns when 
 - `SharpClaw.Api/`
 	- Minimal API backend
 	- Serves health, session, streaming, permissions, and agent-management endpoints
+- `SharpClaw.Anthropic/`
+	- Anthropic backend integration via the `Anthropic` NuGet package
 - `SharpClaw.Core/`
 	- `AgentRunner`
 	- `SessionStore`
@@ -862,6 +865,7 @@ These seeds are inserted safely and do not overwrite user-edited definitions.
 
 ### Anthropic Backend
 
+- Implemented in `SharpClaw.Anthropic/`
 - Uses the configured model from the stored agent definition
 - Requires `ANTHROPIC_API_KEY`
 
@@ -872,6 +876,14 @@ These seeds are inserted safely and do not overwrite user-edited definitions.
 - Supports streaming and tool use
 - Default model: `gpt-4o-mini`
 - Available models are surfaced via `GET /api/backends/openai/models`
+
+### OpenRouter Backend
+
+- Uses the OpenAI-compatible Chat Completions API at `https://openrouter.ai/api/v1`
+- Requires `OPENROUTER_API_KEY`
+- Supports streaming and tool use
+- Default model: `openai/gpt-4o-mini`
+- Available models are surfaced via `GET /api/backends/openrouter/models`
 
 ### Copilot Backend
 

--- a/SharpClaw.Anthropic/AnthropicBackend.cs
+++ b/SharpClaw.Anthropic/AnthropicBackend.cs
@@ -1,11 +1,13 @@
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
-using Anthropic;
+using SharpClaw.Core;
+using global::Anthropic;
+using AnthropicMessages = global::Anthropic.Models.Messages;
 using McpContentBlock = ModelContextProtocol.Protocol.ContentBlock;
 using McpTextContentBlock = ModelContextProtocol.Protocol.TextContentBlock;
 
-namespace SharpClaw.Core;
+namespace SharpClaw.Anthropic;
 
 /// <summary>
 /// <see cref="IAgentBackend"/> implementation that uses the Anthropic Messages API.
@@ -16,9 +18,7 @@ public sealed class AnthropicBackend : IAgentBackend
     private readonly AnthropicClient _anthropic;
     private readonly string _model;
 
-    // Cached JsonElement representing the JSON string "object" — used as the
-    // default InputSchema type when the MCP tool schema omits the "type" field.
-    private static readonly JsonElement _objectTypeElement =
+    private static readonly JsonElement ObjectTypeElement =
         JsonDocument.Parse("\"object\"").RootElement.Clone();
 
     public AnthropicBackend(AnthropicClient anthropic, string model = "claude-haiku-4-5-20251001")
@@ -37,26 +37,25 @@ public sealed class AnthropicBackend : IAgentBackend
     {
         var anthropicTools = tools.Select(ToAnthropicTool).ToList();
 
-        // Seed conversation from the caller-supplied history.
-        var messages = new List<Anthropic.Models.Messages.MessageParam>();
+        var messages = new List<AnthropicMessages.MessageParam>();
         foreach (var msg in history)
         {
-            messages.Add(new Anthropic.Models.Messages.MessageParam
+            messages.Add(new AnthropicMessages.MessageParam
             {
                 Role = msg.Role == ChatRole.User
-                    ? Anthropic.Models.Messages.Role.User
-                    : Anthropic.Models.Messages.Role.Assistant,
-                Content = new Anthropic.Models.Messages.MessageParamContent(msg.Content),
+                    ? AnthropicMessages.Role.User
+                    : AnthropicMessages.Role.Assistant,
+                Content = new AnthropicMessages.MessageParamContent(msg.Content),
             });
         }
 
         var iteration = 0;
         while (true)
         {
-            onProgress?.Invoke(iteration == 0 ? "Thinking…" : "Processing tool results…");
+            onProgress?.Invoke(iteration == 0 ? "Thinking..." : "Processing tool results...");
 
             var response = await _anthropic.Messages.Create(
-                new Anthropic.Models.Messages.MessageCreateParams
+                new AnthropicMessages.MessageCreateParams
                 {
                     Model = _model,
                     MaxTokens = 4096,
@@ -66,51 +65,50 @@ public sealed class AnthropicBackend : IAgentBackend
                 },
                 cancellationToken);
 
-            // Append the assistant turn to the conversation history.
             var assistantBlocks = ResponseBlocksToParams(response.Content);
-            messages.Add(new Anthropic.Models.Messages.MessageParam
+            messages.Add(new AnthropicMessages.MessageParam
             {
-                Role = Anthropic.Models.Messages.Role.Assistant,
-                Content = new Anthropic.Models.Messages.MessageParamContent(assistantBlocks),
+                Role = AnthropicMessages.Role.Assistant,
+                Content = new AnthropicMessages.MessageParamContent(assistantBlocks),
             });
 
-            if (response.StopReason?.Value() != Anthropic.Models.Messages.StopReason.ToolUse)
+            if (response.StopReason?.Value() != AnthropicMessages.StopReason.ToolUse)
             {
                 foreach (var block in response.Content)
                 {
                     if (block.TryPickText(out var textBlock))
                         return textBlock.Text;
                 }
+
                 return string.Empty;
             }
 
-            // Execute every tool call the model requested.
-            var toolResults = new List<Anthropic.Models.Messages.ContentBlockParam>();
+            var toolResults = new List<AnthropicMessages.ContentBlockParam>();
 
             foreach (var block in response.Content)
             {
                 if (!block.TryPickToolUse(out var toolUse))
                     continue;
 
-                onProgress?.Invoke($"  ↳ {toolUse.Name}");
+                onProgress?.Invoke($"  -> {toolUse.Name}");
 
                 var args = new JsonElementArgs(toolUse.Input);
                 var call = new ToolCall(toolUse.Name, args);
                 var result = await toolDispatcher(call, cancellationToken);
 
-                toolResults.Add(new Anthropic.Models.Messages.ContentBlockParam(
-                    new Anthropic.Models.Messages.ToolResultBlockParam(toolUse.ID)
+                toolResults.Add(new AnthropicMessages.ContentBlockParam(
+                    new AnthropicMessages.ToolResultBlockParam(toolUse.ID)
                     {
-                        Content = new Anthropic.Models.Messages.ToolResultBlockParamContent(result.Content),
+                        Content = new AnthropicMessages.ToolResultBlockParamContent(result.Content),
                         IsError = result.IsError,
                     },
                     element: null));
             }
 
-            messages.Add(new Anthropic.Models.Messages.MessageParam
+            messages.Add(new AnthropicMessages.MessageParam
             {
-                Role = Anthropic.Models.Messages.Role.User,
-                Content = new Anthropic.Models.Messages.MessageParamContent(toolResults),
+                Role = AnthropicMessages.Role.User,
+                Content = new AnthropicMessages.MessageParamContent(toolResults),
             });
 
             iteration++;
@@ -126,15 +124,15 @@ public sealed class AnthropicBackend : IAgentBackend
     {
         var anthropicTools = tools.Select(ToAnthropicTool).ToList();
 
-        var messages = new List<Anthropic.Models.Messages.MessageParam>();
+        var messages = new List<AnthropicMessages.MessageParam>();
         foreach (var msg in history)
         {
-            messages.Add(new Anthropic.Models.Messages.MessageParam
+            messages.Add(new AnthropicMessages.MessageParam
             {
                 Role = msg.Role == ChatRole.User
-                    ? Anthropic.Models.Messages.Role.User
-                    : Anthropic.Models.Messages.Role.Assistant,
-                Content = new Anthropic.Models.Messages.MessageParamContent(msg.Content),
+                    ? AnthropicMessages.Role.User
+                    : AnthropicMessages.Role.Assistant,
+                Content = new AnthropicMessages.MessageParamContent(msg.Content),
             });
         }
 
@@ -144,7 +142,7 @@ public sealed class AnthropicBackend : IAgentBackend
         while (true)
         {
             var stream = _anthropic.Messages.CreateStreaming(
-                new Anthropic.Models.Messages.MessageCreateParams
+                new AnthropicMessages.MessageCreateParams
                 {
                     Model = _model,
                     MaxTokens = 4096,
@@ -154,9 +152,8 @@ public sealed class AnthropicBackend : IAgentBackend
                 },
                 cancellationToken);
 
-            // Accumulate the full response for the conversation history / tool-use loop.
             var fullText = new StringBuilder();
-            var assistantBlocks = new List<Anthropic.Models.Messages.ContentBlockParam>();
+            var assistantBlocks = new List<AnthropicMessages.ContentBlockParam>();
             var pendingTools = new List<(string Id, string Name, string InputJson)>();
             StringBuilder? curTextBlock = null;
             string? curToolId = null;
@@ -219,14 +216,13 @@ public sealed class AnthropicBackend : IAgentBackend
                         var inputJson = curToolInput.ToString();
                         pendingTools.Add((curToolId, curToolName!, inputJson));
 
-                        // Build the assistant-side ToolUseBlockParam for the conversation history.
                         var parsedInput = string.IsNullOrEmpty(inputJson)
                             ? new Dictionary<string, JsonElement>()
                             : JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(inputJson)
                               ?? new Dictionary<string, JsonElement>();
 
-                        assistantBlocks.Add(new Anthropic.Models.Messages.ContentBlockParam(
-                            new Anthropic.Models.Messages.ToolUseBlockParam
+                        assistantBlocks.Add(new AnthropicMessages.ContentBlockParam(
+                            new AnthropicMessages.ToolUseBlockParam
                             {
                                 ID = curToolId,
                                 Name = curToolName!,
@@ -242,9 +238,8 @@ public sealed class AnthropicBackend : IAgentBackend
                     {
                         if (curTextBlock.Length > 0)
                         {
-                            // Text block finished — add only this block to the assistant history.
-                            assistantBlocks.Add(new Anthropic.Models.Messages.ContentBlockParam(
-                                new Anthropic.Models.Messages.TextBlockParam(curTextBlock.ToString()),
+                            assistantBlocks.Add(new AnthropicMessages.ContentBlockParam(
+                                new AnthropicMessages.TextBlockParam(curTextBlock.ToString()),
                                 element: null));
                         }
 
@@ -256,13 +251,12 @@ public sealed class AnthropicBackend : IAgentBackend
             totalInputTokens += iterationInputTokens;
             totalOutputTokens += iterationOutputTokens;
 
-            // Append the assistant turn to the conversation.
             if (assistantBlocks.Count > 0)
             {
-                messages.Add(new Anthropic.Models.Messages.MessageParam
+                messages.Add(new AnthropicMessages.MessageParam
                 {
-                    Role = Anthropic.Models.Messages.Role.Assistant,
-                    Content = new Anthropic.Models.Messages.MessageParamContent(assistantBlocks),
+                    Role = AnthropicMessages.Role.Assistant,
+                    Content = new AnthropicMessages.MessageParamContent(assistantBlocks),
                 });
             }
 
@@ -273,8 +267,7 @@ public sealed class AnthropicBackend : IAgentBackend
                 yield break;
             }
 
-            // Execute all pending tool calls and build the user turn.
-            var toolResults = new List<Anthropic.Models.Messages.ContentBlockParam>();
+            var toolResults = new List<AnthropicMessages.ContentBlockParam>();
             foreach (var (id, name, inputJson) in pendingTools)
             {
                 var parsedArgs = string.IsNullOrEmpty(inputJson)
@@ -289,46 +282,42 @@ public sealed class AnthropicBackend : IAgentBackend
                 var result = await toolDispatcher(call, cancellationToken);
                 yield return new ToolResultEvent(name, result.Content, result.IsError);
 
-                toolResults.Add(new Anthropic.Models.Messages.ContentBlockParam(
-                    new Anthropic.Models.Messages.ToolResultBlockParam(id)
+                toolResults.Add(new AnthropicMessages.ContentBlockParam(
+                    new AnthropicMessages.ToolResultBlockParam(id)
                     {
-                        Content = new Anthropic.Models.Messages.ToolResultBlockParamContent(result.Content),
+                        Content = new AnthropicMessages.ToolResultBlockParamContent(result.Content),
                         IsError = result.IsError,
                     },
                     element: null));
             }
 
-            messages.Add(new Anthropic.Models.Messages.MessageParam
+            messages.Add(new AnthropicMessages.MessageParam
             {
-                Role = Anthropic.Models.Messages.Role.User,
-                Content = new Anthropic.Models.Messages.MessageParamContent(toolResults),
+                Role = AnthropicMessages.Role.User,
+                Content = new AnthropicMessages.MessageParamContent(toolResults),
             });
-
-            // Loop back to stream the model's next response.
         }
     }
 
     public ValueTask DisposeAsync() => default;
 
-    // ─── Helpers ────────────────────────────────────────────────────────────
-
-    private static List<Anthropic.Models.Messages.ContentBlockParam> ResponseBlocksToParams(
-        IReadOnlyList<Anthropic.Models.Messages.ContentBlock> blocks)
+    private static List<AnthropicMessages.ContentBlockParam> ResponseBlocksToParams(
+        IReadOnlyList<AnthropicMessages.ContentBlock> blocks)
     {
-        var result = new List<Anthropic.Models.Messages.ContentBlockParam>(blocks.Count);
+        var result = new List<AnthropicMessages.ContentBlockParam>(blocks.Count);
 
         foreach (var block in blocks)
         {
             if (block.TryPickText(out var textBlock))
             {
-                result.Add(new Anthropic.Models.Messages.ContentBlockParam(
-                    new Anthropic.Models.Messages.TextBlockParam(textBlock.Text),
+                result.Add(new AnthropicMessages.ContentBlockParam(
+                    new AnthropicMessages.TextBlockParam(textBlock.Text),
                     element: null));
             }
             else if (block.TryPickToolUse(out var toolUse))
             {
-                result.Add(new Anthropic.Models.Messages.ContentBlockParam(
-                    new Anthropic.Models.Messages.ToolUseBlockParam
+                result.Add(new AnthropicMessages.ContentBlockParam(
+                    new AnthropicMessages.ToolUseBlockParam
                     {
                         ID = toolUse.ID,
                         Name = toolUse.Name,
@@ -349,11 +338,11 @@ public sealed class AnthropicBackend : IAgentBackend
         return string.Join("\n", parts);
     }
 
-    private static Anthropic.Models.Messages.ToolUnion ToAnthropicTool(ToolSchema schema)
+    private static AnthropicMessages.ToolUnion ToAnthropicTool(ToolSchema schema)
     {
         var typeEl = schema.InputSchema.TryGetProperty("type", out var t)
             ? t
-            : _objectTypeElement;
+            : ObjectTypeElement;
 
         Dictionary<string, JsonElement>? propsDict = null;
         if (schema.InputSchema.TryGetProperty("properties", out var propsEl))
@@ -363,45 +352,18 @@ public sealed class AnthropicBackend : IAgentBackend
         if (schema.InputSchema.TryGetProperty("required", out var reqEl))
             requiredList = reqEl.EnumerateArray().Select(e => e.GetString()!).ToList();
 
-        var inputSchema = new Anthropic.Models.Messages.InputSchema
+        var inputSchema = new AnthropicMessages.InputSchema
         {
             Type = typeEl,
             Properties = propsDict,
             Required = requiredList,
         };
 
-        return new Anthropic.Models.Messages.ToolUnion(new Anthropic.Models.Messages.Tool
+        return new AnthropicMessages.ToolUnion(new AnthropicMessages.Tool
         {
             Name = schema.Name,
             Description = schema.Description,
             InputSchema = inputSchema,
         });
     }
-}
-
-/// <summary>
-/// Adapts <see cref="IReadOnlyDictionary{String, JsonElement}"/> to
-/// <see cref="IReadOnlyDictionary{String, Object}"/> without copying entries.
-/// </summary>
-internal sealed class JsonElementArgs : IReadOnlyDictionary<string, object?>
-{
-    private readonly IReadOnlyDictionary<string, JsonElement> _inner;
-
-    internal JsonElementArgs(IReadOnlyDictionary<string, JsonElement> inner) =>
-        _inner = inner;
-
-    public object? this[string key] => _inner[key];
-    public IEnumerable<string> Keys => _inner.Keys;
-    public IEnumerable<object?> Values => _inner.Values.Cast<object?>();
-    public int Count => _inner.Count;
-    public bool ContainsKey(string key) => _inner.ContainsKey(key);
-    public bool TryGetValue(string key, out object? value)
-    {
-        if (_inner.TryGetValue(key, out var el)) { value = el; return true; }
-        value = null;
-        return false;
-    }
-    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
-        _inner.Select(kvp => KeyValuePair.Create(kvp.Key, (object?)kvp.Value)).GetEnumerator();
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/SharpClaw.Anthropic/AnthropicBackendProvider.cs
+++ b/SharpClaw.Anthropic/AnthropicBackendProvider.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using SharpClaw.Core;
+using global::Anthropic;
+using global::Anthropic.Core;
+
+namespace SharpClaw.Anthropic;
+
+public sealed class AnthropicBackendProvider : IAgentBackendProvider
+{
+    public const string Name = "anthropic";
+    public const string DefaultModel = "claude-haiku-4-5-20251001";
+    public const string ApiKeyEnvVar = "ANTHROPIC_API_KEY";
+
+    private static readonly HttpClient HttpClient = new();
+
+    public string BackendName => Name;
+
+    public IAgentBackend CreateBackend(AgentPersona persona, PermissionGate permissionGate)
+    {
+        return CreateBackend(string.IsNullOrWhiteSpace(persona.Model) ? DefaultModel : persona.Model);
+    }
+
+    public async Task<IReadOnlyList<BackendModelInfo>> ListModelsAsync(CancellationToken cancellationToken)
+    {
+        var apiKey = BackendProviderUtilities.GetRequiredEnvironmentVariable(ApiKeyEnvVar);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.anthropic.com/v1/models");
+        request.Headers.Add("x-api-key", apiKey);
+        request.Headers.Add("anthropic-version", "2023-06-01");
+
+        using var document = await BackendProviderUtilities.SendJsonRequestAsync(
+            HttpClient,
+            request,
+            "Anthropic model list request",
+            cancellationToken);
+        if (!BackendProviderUtilities.TryGetDataArray(document, out var data))
+            return [];
+
+        var models = new List<BackendModelInfo>();
+        foreach (var item in data.EnumerateArray())
+        {
+            if (!item.TryGetProperty("id", out var idElement))
+                continue;
+
+            var id = idElement.GetString();
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            var displayName = item.TryGetProperty("display_name", out var nameElement)
+                ? nameElement.GetString()
+                : null;
+
+            models.Add(new BackendModelInfo(id, string.IsNullOrWhiteSpace(displayName) ? id : displayName));
+        }
+
+        return models;
+    }
+
+    public static IAgentBackend CreateBackend(string model = DefaultModel)
+    {
+        var apiKey = BackendProviderUtilities.GetRequiredEnvironmentVariable(ApiKeyEnvVar);
+
+        return new AnthropicBackend(new AnthropicClient(new ClientOptions
+        {
+            ApiKey = apiKey,
+        }), model);
+    }
+}

--- a/SharpClaw.Anthropic/JsonElementArgs.cs
+++ b/SharpClaw.Anthropic/JsonElementArgs.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+
+namespace SharpClaw.Anthropic;
+
+internal sealed class JsonElementArgs : IReadOnlyDictionary<string, object?>
+{
+    private readonly IReadOnlyDictionary<string, JsonElement> _inner;
+
+    internal JsonElementArgs(IReadOnlyDictionary<string, JsonElement> inner) =>
+        _inner = inner;
+
+    public object? this[string key] => _inner[key];
+    public IEnumerable<string> Keys => _inner.Keys;
+    public IEnumerable<object?> Values => _inner.Values.Cast<object?>();
+    public int Count => _inner.Count;
+
+    public bool ContainsKey(string key) => _inner.ContainsKey(key);
+
+    public bool TryGetValue(string key, out object? value)
+    {
+        if (_inner.TryGetValue(key, out var element))
+        {
+            value = element;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
+        _inner.Select(kvp => KeyValuePair.Create(kvp.Key, (object?)kvp.Value)).GetEnumerator();
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/SharpClaw.Anthropic/SharpClaw.Anthropic.csproj
+++ b/SharpClaw.Anthropic/SharpClaw.Anthropic.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharpClaw.Core\SharpClaw.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Anthropic" Version="12.9.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/SharpClaw.Api/ApiMapper.cs
+++ b/SharpClaw.Api/ApiMapper.cs
@@ -108,7 +108,7 @@ internal static class ApiMapper
             linkedAgentCount);
 
     internal static BackendModelsResponse ToBackendModelsDto(
-        IReadOnlyList<(string Id, string DisplayName)> models,
+        IReadOnlyList<BackendModelInfo> models,
         string source,
         DateTimeOffset? cachedAt = null,
         string? warning = null) =>

--- a/SharpClaw.Api/ApiValidator.cs
+++ b/SharpClaw.Api/ApiValidator.cs
@@ -5,7 +5,10 @@ namespace SharpClaw.Api;
 
 internal static class ApiValidator
 {
-    internal static string? ValidateAgentRequest(SessionStore store, AgentDefinitionRequest req)
+    internal static string? ValidateAgentRequest(
+        SessionStore store,
+        IReadOnlyCollection<string> backendNames,
+        AgentDefinitionRequest req)
     {
         if (string.IsNullOrWhiteSpace(req.Name))
             return "name is required.";
@@ -17,8 +20,11 @@ internal static class ApiValidator
             return "systemPrompt is required.";
 
         var backend = req.Backend.Trim().ToLowerInvariant();
-        if (backend is not ("anthropic" or "copilot" or "openai" or "openrouter"))
-            return "backend must be 'anthropic', 'copilot', 'openai', or 'openrouter'.";
+        if (!backendNames.Contains(backend, StringComparer.OrdinalIgnoreCase))
+        {
+            var formattedNames = string.Join(", ", backendNames.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).Select(name => $"'{name}'"));
+            return $"backend must be {formattedNames}.";
+        }
 
         var unknownMcp = ApiMapper.NormalizeStringList(req.McpServers)
             .FirstOrDefault(slug => store.GetMcp(slug) is null);

--- a/SharpClaw.Api/Controllers/AgentsController.cs
+++ b/SharpClaw.Api/Controllers/AgentsController.cs
@@ -9,6 +9,7 @@ namespace SharpClaw.Api.Controllers;
 [Route("api")]
 public sealed class AgentsController(
     SessionStore store,
+    BackendRegistry backendRegistry,
     BackendModelService backendModelService,
     SessionRuntimeService runtimeService) : ControllerBase
 {
@@ -51,7 +52,7 @@ public sealed class AgentsController(
     [ProducesResponseType<ErrorResponse>(StatusCodes.Status409Conflict)]
     public IActionResult CreateAgent([FromBody] AgentDefinitionRequest req)
     {
-        var error = ApiValidator.ValidateAgentRequest(store, req);
+        var error = ApiValidator.ValidateAgentRequest(store, backendRegistry.BackendNames, req);
         if (error is not null)
             return BadRequest(new ErrorResponse(error));
 
@@ -71,7 +72,7 @@ public sealed class AgentsController(
     [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
     public IActionResult UpdateAgent(string slug, [FromBody] AgentDefinitionRequest req)
     {
-        var error = ApiValidator.ValidateAgentRequest(store, req);
+        var error = ApiValidator.ValidateAgentRequest(store, backendRegistry.BackendNames, req);
         if (error is not null)
             return BadRequest(new ErrorResponse(error));
 

--- a/SharpClaw.Api/Program.cs
+++ b/SharpClaw.Api/Program.cs
@@ -1,7 +1,11 @@
 using Scalar.AspNetCore;
 using SharpClaw.Api.Middleware;
 using SharpClaw.Api.Services;
+using SharpClaw.Anthropic;
+using SharpClaw.Copilot;
 using SharpClaw.Core;
+using SharpClaw.OpenAI;
+using SharpClaw.OpenRouter;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,6 +21,11 @@ if (string.IsNullOrWhiteSpace(connectionString))
 
 builder.Services.AddSingleton(new SessionStore(connectionString));
 builder.Services.AddHttpClient();
+builder.Services.AddSingleton<IAgentBackendProvider, AnthropicBackendProvider>();
+builder.Services.AddSingleton<IAgentBackendProvider, CopilotBackendProvider>();
+builder.Services.AddSingleton<IAgentBackendProvider, OpenAIBackendProvider>();
+builder.Services.AddSingleton<IAgentBackendProvider, OpenRouterBackendProvider>();
+builder.Services.AddSingleton<BackendRegistry>();
 builder.Services.AddSingleton<BackendModelService>();
 builder.Services.AddSingleton<SessionRuntimeService>();
 builder.Services.AddControllers();

--- a/SharpClaw.Api/Services/BackendModelService.cs
+++ b/SharpClaw.Api/Services/BackendModelService.cs
@@ -1,36 +1,27 @@
 using System.Collections.Concurrent;
-using System.Text.Json;
-using Anthropic.Core;
-using GitHub.Copilot.SDK;
 using SharpClaw.Api.Models;
+using SharpClaw.Core;
 
 namespace SharpClaw.Api.Services;
 
-public sealed class BackendModelService(IHttpClientFactory httpClientFactory)
+public sealed class BackendModelService(BackendRegistry backendRegistry)
 {
-    private readonly ConcurrentDictionary<string, (DateTimeOffset CachedAt, IReadOnlyList<(string Id, string DisplayName)> Models)> _backendModelCache =
+    private readonly ConcurrentDictionary<string, (DateTimeOffset CachedAt, IReadOnlyList<BackendModelInfo> Models)> _backendModelCache =
         new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<ApiResponse<IApiPayload>> GetModelsAsync(string backend, CancellationToken cancellationToken)
     {
         var normalizedBackend = backend.Trim().ToLowerInvariant();
-        if (normalizedBackend is not ("anthropic" or "copilot" or "openai" or "openrouter"))
+        if (!backendRegistry.TryGet(normalizedBackend, out var provider))
         {
             return new ApiResponse<IApiPayload>(
                 StatusCodes.Status400BadRequest,
-                new ErrorResponse("backend must be 'anthropic', 'copilot', 'openai', or 'openrouter'."));
+                new ErrorResponse(backendRegistry.BuildSupportedBackendsMessage()));
         }
 
         try
         {
-            var models = normalizedBackend switch
-            {
-                "anthropic" => await ListAnthropicModelsAsync(cancellationToken),
-                "copilot" => await ListCopilotModelsAsync(cancellationToken),
-                "openai" => await ListOpenAiModelsAsync(cancellationToken),
-                "openrouter" => await ListOpenRouterModelsAsync(cancellationToken),
-                _ => [],
-            };
+            var models = await provider.ListModelsAsync(cancellationToken);
 
             _backendModelCache[normalizedBackend] = (DateTimeOffset.UtcNow, models);
 
@@ -66,193 +57,5 @@ public sealed class BackendModelService(IHttpClientFactory httpClientFactory)
                     $"Failed to load models for backend '{normalizedBackend}'.",
                     ex.Message));
         }
-    }
-
-    private static CopilotClient CreateCopilotClient()
-    {
-        var opts = new CopilotClientOptions
-        {
-            Cwd = Environment.GetEnvironmentVariable("SHARPCLAW_WORKSPACE") ?? Environment.CurrentDirectory,
-        };
-
-        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-        if (string.IsNullOrWhiteSpace(token))
-            token = Environment.GetEnvironmentVariable("GITHUB_COPILOT_TOKEN");
-        if (string.IsNullOrWhiteSpace(token))
-            token = TryGetGhToken();
-
-        if (!string.IsNullOrWhiteSpace(token))
-            opts.GitHubToken = token;
-
-        return new CopilotClient(opts);
-    }
-
-    private static string? TryGetGhToken()
-    {
-        try
-        {
-            var psi = new System.Diagnostics.ProcessStartInfo("gh", "auth token")
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-            };
-
-            using var proc = System.Diagnostics.Process.Start(psi);
-            if (proc is null)
-                return null;
-
-            var output = proc.StandardOutput.ReadToEnd().Trim();
-            proc.WaitForExit(5000);
-            return proc.ExitCode == 0 && output.StartsWith("gho_") ? output : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static async Task<IReadOnlyList<(string Id, string DisplayName)>> ListCopilotModelsAsync(CancellationToken cancellationToken)
-    {
-        await using var client = CreateCopilotClient();
-        await client.StartAsync(cancellationToken);
-
-        var response = await client.ListModelsAsync(cancellationToken);
-        return response
-            .Where(model => !string.IsNullOrWhiteSpace(model.Id))
-            .Select(model => (
-                model.Id,
-                string.IsNullOrWhiteSpace(model.Name) ? model.Id : model.Name))
-            .ToList();
-    }
-
-    private async Task<IReadOnlyList<(string Id, string DisplayName)>> ListAnthropicModelsAsync(CancellationToken cancellationToken)
-    {
-        var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
-        if (string.IsNullOrWhiteSpace(apiKey))
-            throw new InvalidOperationException("ANTHROPIC_API_KEY is not set.");
-
-        using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.anthropic.com/v1/models");
-        request.Headers.Add("x-api-key", apiKey);
-        request.Headers.Add("anthropic-version", "2023-06-01");
-
-        using var httpClient = httpClientFactory.CreateClient();
-        using var response = await httpClient.SendAsync(request, cancellationToken);
-        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException(
-                $"Anthropic model list request failed with {(int)response.StatusCode}: {responseBody}");
-        }
-
-        using var document = JsonDocument.Parse(responseBody);
-        if (!document.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
-            return [];
-
-        var models = new List<(string Id, string DisplayName)>();
-        foreach (var item in data.EnumerateArray())
-        {
-            if (!item.TryGetProperty("id", out var idElement))
-                continue;
-
-            var id = idElement.GetString();
-            if (string.IsNullOrWhiteSpace(id))
-                continue;
-
-            var displayName = item.TryGetProperty("display_name", out var nameElement)
-                ? nameElement.GetString()
-                : null;
-
-            models.Add((id, string.IsNullOrWhiteSpace(displayName) ? id : displayName));
-        }
-
-        return models;
-    }
-
-    private async Task<IReadOnlyList<(string Id, string DisplayName)>> ListOpenAiModelsAsync(CancellationToken cancellationToken)
-    {
-        var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
-        if (string.IsNullOrWhiteSpace(apiKey))
-            throw new InvalidOperationException("OPENAI_API_KEY is not set.");
-
-        using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.openai.com/v1/models");
-        request.Headers.Add("Authorization", $"Bearer {apiKey}");
-
-        using var httpClient = httpClientFactory.CreateClient();
-        using var response = await httpClient.SendAsync(request, cancellationToken);
-        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException(
-                $"OpenAI model list request failed with {(int)response.StatusCode}: {responseBody}");
-        }
-
-        using var document = JsonDocument.Parse(responseBody);
-        if (!document.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
-            return [];
-
-        var models = new List<(string Id, string DisplayName)>();
-        foreach (var item in data.EnumerateArray())
-        {
-            if (!item.TryGetProperty("id", out var idElement))
-                continue;
-
-            var id = idElement.GetString();
-            if (string.IsNullOrWhiteSpace(id))
-                continue;
-
-            // Only surface chat-capable models: gpt-* series and o-series (o1, o2, o3, … oN).
-            if (!id.StartsWith("gpt-", StringComparison.OrdinalIgnoreCase) &&
-                !(id.Length > 1 && id[0] is 'o' or 'O' && char.IsDigit(id[1])))
-                continue;
-
-            models.Add((id, id));
-        }
-
-        models.Sort((a, b) => string.Compare(a.Id, b.Id, StringComparison.OrdinalIgnoreCase));
-        return models;
-    }
-
-    private async Task<IReadOnlyList<(string Id, string DisplayName)>> ListOpenRouterModelsAsync(CancellationToken cancellationToken)
-    {
-        var apiKey = Environment.GetEnvironmentVariable("OPENROUTER_API_KEY");
-        if (string.IsNullOrWhiteSpace(apiKey))
-            throw new InvalidOperationException("OPENROUTER_API_KEY is not set.");
-
-        using var request = new HttpRequestMessage(HttpMethod.Get, "https://openrouter.ai/api/v1/models");
-        request.Headers.Add("Authorization", $"Bearer {apiKey}");
-
-        using var httpClient = httpClientFactory.CreateClient();
-        using var response = await httpClient.SendAsync(request, cancellationToken);
-        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException(
-                $"OpenRouter model list request failed with {(int)response.StatusCode}: {responseBody}");
-        }
-
-        using var document = JsonDocument.Parse(responseBody);
-        if (!document.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
-            return [];
-
-        var models = new List<(string Id, string DisplayName)>();
-        foreach (var item in data.EnumerateArray())
-        {
-            if (!item.TryGetProperty("id", out var idElement))
-                continue;
-
-            var id = idElement.GetString();
-            if (string.IsNullOrWhiteSpace(id))
-                continue;
-
-            var displayName = item.TryGetProperty("name", out var nameElement)
-                ? nameElement.GetString()
-                : null;
-
-            models.Add((id, string.IsNullOrWhiteSpace(displayName) ? id : displayName));
-        }
-
-        models.Sort((a, b) => string.Compare(a.Id, b.Id, StringComparison.OrdinalIgnoreCase));
-        return models;
     }
 }

--- a/SharpClaw.Api/Services/BackendRegistry.cs
+++ b/SharpClaw.Api/Services/BackendRegistry.cs
@@ -1,0 +1,37 @@
+using SharpClaw.Core;
+
+namespace SharpClaw.Api.Services;
+
+public sealed class BackendRegistry(IEnumerable<IAgentBackendProvider> providers)
+{
+    private readonly Dictionary<string, IAgentBackendProvider> _providers = BuildProviderMap(providers);
+
+    public IReadOnlyList<string> BackendNames => _providers.Keys
+        .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    public bool TryGet(string backend, out IAgentBackendProvider provider)
+        => _providers.TryGetValue(backend.Trim(), out provider!);
+
+    public string BuildSupportedBackendsMessage(string fieldName = "backend")
+    {
+        var formattedNames = string.Join(", ", BackendNames.Select(name => $"'{name}'"));
+        return $"{fieldName} must be {formattedNames}.";
+    }
+
+    private static Dictionary<string, IAgentBackendProvider> BuildProviderMap(IEnumerable<IAgentBackendProvider> providers)
+    {
+        var map = new Dictionary<string, IAgentBackendProvider>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var provider in providers)
+        {
+            if (!map.TryAdd(provider.BackendName, provider))
+            {
+                throw new InvalidOperationException(
+                    $"Duplicate backend provider registration for '{provider.BackendName}'.");
+            }
+        }
+
+        return map;
+    }
+}

--- a/SharpClaw.Api/Services/SessionRuntimeService.cs
+++ b/SharpClaw.Api/Services/SessionRuntimeService.cs
@@ -2,17 +2,16 @@ using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Channels;
-using Anthropic;
-using Anthropic.Core;
 using SharpClaw.Api.Models;
-using SharpClaw.Copilot;
+using SharpClaw.Anthropic;
 using SharpClaw.Core;
-using SharpClaw.OpenAI;
-using SharpClaw.OpenRouter;
 
 namespace SharpClaw.Api.Services;
 
-public sealed class SessionRuntimeService(SessionStore store, ILogger<SessionRuntimeService> logger)
+public sealed class SessionRuntimeService(
+    SessionStore store,
+    BackendRegistry backendRegistry,
+    ILogger<SessionRuntimeService> logger)
 {
     private readonly ConcurrentDictionary<string, AgentRunner> _runners = new();
     private readonly ConcurrentDictionary<string, Channel<AgentEvent>> _messageStreams = new();
@@ -177,25 +176,13 @@ public sealed class SessionRuntimeService(SessionStore store, ILogger<SessionRun
         return new AgentRunner(persona, mcps, CreateBackend);
     }
 
-    private IAgentBackend CreateBackend(AgentPersona persona, PermissionGate gate) => persona.Backend switch
+    private IAgentBackend CreateBackend(AgentPersona persona, PermissionGate gate)
     {
-        "anthropic" => new AnthropicBackend(new AnthropicClient(new ClientOptions
-        {
-            ApiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY")
-                ?? throw new InvalidOperationException("ANTHROPIC_API_KEY is not set."),
-        }), string.IsNullOrWhiteSpace(persona.Model) ? "claude-haiku-4-5-20251001" : persona.Model),
-        "copilot" => new CopilotBackend(gate,
-            Environment.GetEnvironmentVariable("SHARPCLAW_WORKSPACE") ?? Environment.CurrentDirectory),
-        "openai" => new OpenAIBackend(
-            Environment.GetEnvironmentVariable("OPENAI_API_KEY")
-                ?? throw new InvalidOperationException("OPENAI_API_KEY is not set."),
-            string.IsNullOrWhiteSpace(persona.Model) ? "gpt-4o-mini" : persona.Model),
-        "openrouter" => new OpenRouterBackend(
-            Environment.GetEnvironmentVariable("OPENROUTER_API_KEY")
-                ?? throw new InvalidOperationException("OPENROUTER_API_KEY is not set."),
-            string.IsNullOrWhiteSpace(persona.Model) ? "openai/gpt-4o-mini" : persona.Model),
-        _ => throw new InvalidOperationException($"Unknown backend '{persona.Backend}'."),
-    };
+        if (!backendRegistry.TryGet(persona.Backend, out var provider))
+            throw new InvalidOperationException($"Unknown backend '{persona.Backend}'.");
+
+        return provider.CreateBackend(persona, gate);
+    }
 
     private async Task RunMessageTurnAsync(
         string sessionId,
@@ -282,11 +269,7 @@ public sealed class SessionRuntimeService(SessionStore store, ILogger<SessionRun
                     messageId);
 
                 var routingAgent = new RoutingAgent(
-                    new AnthropicBackend(new AnthropicClient(
-                        new ClientOptions
-                        {
-                            ApiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY")!
-                        })),
+                    AnthropicBackendProvider.CreateBackend(),
                     adeRecord.ToPersona());
 
                 var decision = await routingAgent.RouteAsync(message, availableAgents);

--- a/SharpClaw.Api/SharpClaw.Api.csproj
+++ b/SharpClaw.Api/SharpClaw.Api.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <ProjectReference Include="..\SharpClaw.Anthropic\SharpClaw.Anthropic.csproj" />
     <ProjectReference Include="..\SharpClaw.Core\SharpClaw.Core.csproj" />
     <ProjectReference Include="..\SharpClaw.Copilot\SharpClaw.Copilot.csproj" />
     <ProjectReference Include="..\SharpClaw.OpenAI\SharpClaw.OpenAI.csproj" />

--- a/SharpClaw.Copilot/CopilotBackendProvider.cs
+++ b/SharpClaw.Copilot/CopilotBackendProvider.cs
@@ -1,0 +1,79 @@
+using GitHub.Copilot.SDK;
+using SharpClaw.Core;
+
+namespace SharpClaw.Copilot;
+
+public sealed class CopilotBackendProvider : IAgentBackendProvider
+{
+    public const string Name = "copilot";
+    public const string WorkspaceEnvVar = "SHARPCLAW_WORKSPACE";
+    public const string GitHubTokenEnvVar = "GITHUB_TOKEN";
+    public const string CopilotTokenEnvVar = "GITHUB_COPILOT_TOKEN";
+
+    public string BackendName => Name;
+
+    public IAgentBackend CreateBackend(AgentPersona persona, PermissionGate permissionGate)
+    {
+        return new CopilotBackend(
+            permissionGate,
+            Environment.GetEnvironmentVariable(WorkspaceEnvVar) ?? Environment.CurrentDirectory);
+    }
+
+    public async Task<IReadOnlyList<BackendModelInfo>> ListModelsAsync(CancellationToken cancellationToken)
+    {
+        await using var client = CreateCopilotClient();
+        await client.StartAsync(cancellationToken);
+
+        var response = await client.ListModelsAsync(cancellationToken);
+        return response
+            .Where(model => !string.IsNullOrWhiteSpace(model.Id))
+            .Select(model => new BackendModelInfo(
+                model.Id,
+                string.IsNullOrWhiteSpace(model.Name) ? model.Id : model.Name))
+            .ToList();
+    }
+
+    private static CopilotClient CreateCopilotClient()
+    {
+        var options = new CopilotClientOptions
+        {
+            Cwd = Environment.GetEnvironmentVariable(WorkspaceEnvVar) ?? Environment.CurrentDirectory,
+        };
+
+        var token = Environment.GetEnvironmentVariable(GitHubTokenEnvVar);
+        if (string.IsNullOrWhiteSpace(token))
+            token = Environment.GetEnvironmentVariable(CopilotTokenEnvVar);
+        if (string.IsNullOrWhiteSpace(token))
+            token = TryGetGhToken();
+
+        if (!string.IsNullOrWhiteSpace(token))
+            options.GitHubToken = token;
+
+        return new CopilotClient(options);
+    }
+
+    private static string? TryGetGhToken()
+    {
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo("gh", "auth token")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc is null)
+                return null;
+
+            var output = proc.StandardOutput.ReadToEnd().Trim();
+            proc.WaitForExit(5000);
+            return proc.ExitCode == 0 && output.StartsWith("gho_") ? output : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/SharpClaw.Core/AgentRunner.cs
+++ b/SharpClaw.Core/AgentRunner.cs
@@ -1,4 +1,3 @@
-using Anthropic;
 using ModelContextProtocol.Client;
 
 namespace SharpClaw.Core;
@@ -161,22 +160,8 @@ public sealed class AgentRunner : IAsyncDisposable
         if (_backendFactory is not null)
             return _backendFactory(persona, permissionGate);
 
-        return persona.Backend switch
-        {
-            "anthropic" => CreateAnthropicBackend(persona.Model),
-            _ => throw new InvalidOperationException(
-                $"Unknown backend '{persona.Backend}'. Register a backendFactory to support it."),
-        };
-    }
-
-    private static AnthropicBackend CreateAnthropicBackend(string model)
-    {
-        var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
-        if (string.IsNullOrWhiteSpace(apiKey))
-            throw new InvalidOperationException("ANTHROPIC_API_KEY environment variable is not set.");
-
-        var anthropic = new AnthropicClient(new Anthropic.Core.ClientOptions { ApiKey = apiKey });
-        return new AnthropicBackend(anthropic, string.IsNullOrWhiteSpace(model) ? "claude-haiku-4-5-20251001" : model);
+        throw new InvalidOperationException(
+            $"Unknown backend '{persona.Backend}'. Register a backendFactory to support it.");
     }
 
     private static string CreateToolName(string mcpSlug, string rawToolName) => $"{mcpSlug}.{rawToolName}";

--- a/SharpClaw.Core/BackendModelInfo.cs
+++ b/SharpClaw.Core/BackendModelInfo.cs
@@ -1,0 +1,3 @@
+namespace SharpClaw.Core;
+
+public sealed record BackendModelInfo(string Id, string DisplayName);

--- a/SharpClaw.Core/BackendProviderUtilities.cs
+++ b/SharpClaw.Core/BackendProviderUtilities.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+
+namespace SharpClaw.Core;
+
+public static class BackendProviderUtilities
+{
+    public static string GetRequiredEnvironmentVariable(string variableName)
+    {
+        var value = Environment.GetEnvironmentVariable(variableName);
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException($"{variableName} is not set.");
+
+        return value;
+    }
+
+    public static async Task<JsonDocument> SendJsonRequestAsync(
+        HttpClient client,
+        HttpRequestMessage request,
+        string requestDescription,
+        CancellationToken cancellationToken)
+    {
+        using var response = await client.SendAsync(request, cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"{requestDescription} failed with {(int)response.StatusCode}: {responseBody}");
+        }
+
+        return JsonDocument.Parse(responseBody);
+    }
+
+    public static bool TryGetDataArray(JsonDocument document, out JsonElement data)
+    {
+        if (document.RootElement.TryGetProperty("data", out data) && data.ValueKind == JsonValueKind.Array)
+            return true;
+
+        data = default;
+        return false;
+    }
+}

--- a/SharpClaw.Core/IAgentBackendProvider.cs
+++ b/SharpClaw.Core/IAgentBackendProvider.cs
@@ -1,0 +1,10 @@
+namespace SharpClaw.Core;
+
+public interface IAgentBackendProvider
+{
+    string BackendName { get; }
+
+    IAgentBackend CreateBackend(AgentPersona persona, PermissionGate permissionGate);
+
+    Task<IReadOnlyList<BackendModelInfo>> ListModelsAsync(CancellationToken cancellationToken);
+}

--- a/SharpClaw.Core/SharpClaw.Core.csproj
+++ b/SharpClaw.Core/SharpClaw.Core.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Anthropic" Version="12.9.0" />
     <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
   </ItemGroup>

--- a/SharpClaw.OpenAI/OpenAIBackendProvider.cs
+++ b/SharpClaw.OpenAI/OpenAIBackendProvider.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using SharpClaw.Core;
+
+namespace SharpClaw.OpenAI;
+
+public sealed class OpenAIBackendProvider : IAgentBackendProvider
+{
+    public const string Name = "openai";
+    public const string DefaultModel = "gpt-4o-mini";
+    public const string ApiKeyEnvVar = "OPENAI_API_KEY";
+
+    private static readonly HttpClient HttpClient = new();
+
+    public string BackendName => Name;
+
+    public IAgentBackend CreateBackend(AgentPersona persona, PermissionGate permissionGate)
+    {
+        return new OpenAIBackend(
+            BackendProviderUtilities.GetRequiredEnvironmentVariable(ApiKeyEnvVar),
+            string.IsNullOrWhiteSpace(persona.Model) ? DefaultModel : persona.Model);
+    }
+
+    public async Task<IReadOnlyList<BackendModelInfo>> ListModelsAsync(CancellationToken cancellationToken)
+    {
+        var apiKey = BackendProviderUtilities.GetRequiredEnvironmentVariable(ApiKeyEnvVar);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.openai.com/v1/models");
+        request.Headers.Add("Authorization", $"Bearer {apiKey}");
+
+        using var document = await BackendProviderUtilities.SendJsonRequestAsync(
+            HttpClient,
+            request,
+            "OpenAI model list request",
+            cancellationToken);
+        if (!BackendProviderUtilities.TryGetDataArray(document, out var data))
+            return [];
+
+        var models = new List<BackendModelInfo>();
+        foreach (var item in data.EnumerateArray())
+        {
+            if (!item.TryGetProperty("id", out var idElement))
+                continue;
+
+            var id = idElement.GetString();
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            if (!id.StartsWith("gpt-", StringComparison.OrdinalIgnoreCase) &&
+                !(id.Length > 1 && id[0] is 'o' or 'O' && char.IsDigit(id[1])))
+                continue;
+
+            models.Add(new BackendModelInfo(id, id));
+        }
+
+        models.Sort((a, b) => string.Compare(a.Id, b.Id, StringComparison.OrdinalIgnoreCase));
+        return models;
+    }
+}

--- a/SharpClaw.OpenRouter/OpenRouterBackendProvider.cs
+++ b/SharpClaw.OpenRouter/OpenRouterBackendProvider.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using SharpClaw.Core;
+
+namespace SharpClaw.OpenRouter;
+
+public sealed class OpenRouterBackendProvider : IAgentBackendProvider
+{
+    public const string Name = "openrouter";
+    public const string DefaultModel = "openai/gpt-4o-mini";
+    public const string ApiKeyEnvVar = "OPENROUTER_API_KEY";
+
+    private static readonly HttpClient HttpClient = new();
+
+    public string BackendName => Name;
+
+    public IAgentBackend CreateBackend(AgentPersona persona, PermissionGate permissionGate)
+    {
+        return new OpenRouterBackend(
+            BackendProviderUtilities.GetRequiredEnvironmentVariable(ApiKeyEnvVar),
+            string.IsNullOrWhiteSpace(persona.Model) ? DefaultModel : persona.Model);
+    }
+
+    public async Task<IReadOnlyList<BackendModelInfo>> ListModelsAsync(CancellationToken cancellationToken)
+    {
+        var apiKey = BackendProviderUtilities.GetRequiredEnvironmentVariable(ApiKeyEnvVar);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://openrouter.ai/api/v1/models");
+        request.Headers.Add("Authorization", $"Bearer {apiKey}");
+
+        using var document = await BackendProviderUtilities.SendJsonRequestAsync(
+            HttpClient,
+            request,
+            "OpenRouter model list request",
+            cancellationToken);
+        if (!BackendProviderUtilities.TryGetDataArray(document, out var data))
+            return [];
+
+        var models = new List<BackendModelInfo>();
+        foreach (var item in data.EnumerateArray())
+        {
+            if (!item.TryGetProperty("id", out var idElement))
+                continue;
+
+            var id = idElement.GetString();
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            var displayName = item.TryGetProperty("name", out var nameElement)
+                ? nameElement.GetString()
+                : null;
+
+            models.Add(new BackendModelInfo(id, string.IsNullOrWhiteSpace(displayName) ? id : displayName));
+        }
+
+        models.Sort((a, b) => string.Compare(a.Id, b.Id, StringComparison.OrdinalIgnoreCase));
+        return models;
+    }
+}

--- a/SharpClaw.slnx
+++ b/SharpClaw.slnx
@@ -1,4 +1,5 @@
 <Solution>
+  <Project Path="SharpClaw.Anthropic/SharpClaw.Anthropic.csproj" />
   <Project Path="SharpClaw.Api/SharpClaw.Api.csproj" />
   <Project Path="SharpClaw.Copilot/SharpClaw.Copilot.csproj" />
   <Project Path="SharpClaw.Core/SharpClaw.Core.csproj" />


### PR DESCRIPTION
This pull request primarily refactors the Anthropic backend integration by moving its implementation into a new dedicated project, `SharpClaw.Anthropic`, and updates documentation to reflect this change. It also introduces documentation for a new OpenRouter backend and cleans up code in the Anthropic backend for clarity and maintainability.

**Project Structure and Documentation Updates:**

* Moved the Anthropic backend implementation from `SharpClaw.Core` to a new project directory, `SharpClaw.Anthropic/`, and updated all relevant namespaces and references accordingly. [[1]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL4-R10) [[2]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL19-R21)
* Updated the `README.md` to document the new `SharpClaw.Anthropic/` project, clarify the Anthropic backend setup, and add a section for the new OpenRouter backend, including configuration and model information. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R148) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R164-R165) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R868) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R880-R887)

**Codebase Cleanup and Refactoring:**

* Replaced verbose type names with aliases (e.g., `AnthropicMessages`) and removed redundant comments and legacy code, improving code readability in `AnthropicBackend.cs`. [[1]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL4-R10) [[2]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL19-R21) [[3]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL40-R58) [[4]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL69-R111) [[5]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL129-R135) [[6]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL147-R145) [[7]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL157-R156) [[8]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL222-R225) [[9]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL245-R242) [[10]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL259-R259) [[11]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL276-R270) [[12]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL292-R320) [[13]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL352-R345) [[14]](diffhunk://#diff-0b050b2d26b8dd12f47a2a4d53cc9464a83bfd99985b590867b9681a924f619eL366-L407)
* Removed the internal `JsonElementArgs` adapter class from the Anthropic backend, as it is no longer needed.

These changes improve modularity, documentation accuracy, and maintainability of the Anthropic backend integration and introduce support documentation for the OpenRouter backend.