### PR TITLE
Further fixes to env vars and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ POSTGRES_PASSWORD=change-me
 SHARPCLAW_DB_CONNECTION=Host=localhost;Database=sharpclaw;Username=sharpclaw;Password=change-me
 
 SHARPCLAW_JWT_SECRET=replace-with-a-random-secret-at-least-32-characters-long
+GITHUB_PERSONAL_ACCESS_TOKEN=
 
 # Telegram worker integration (optional)
 SHARPCLAW_API_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ SharpClaw now stores MCP definitions in PostgreSQL and resolves them at runtime 
 - `filesystem`
 - `sqlite`
 - `github`
+- `knowledge-base`
+
+The seeded `github` MCP starts disabled by default. It requires `GITHUB_PERSONAL_ACCESS_TOKEN` in the API runtime environment before you enable it.
+
+The seeded `knowledge-base` MCP also starts disabled by default. It resolves to `~/knowledge` for non-Docker runs, `/knowledge` in Docker Compose, and `/var/lib/sharpclaw/knowledge` for systemd service installs.
 
 The filesystem MCP server is constrained to the workspace path, resolved from:
 
@@ -208,6 +213,7 @@ Older flat permission rules are migrated on startup to MCP-scoped patterns when 
 | `POSTGRES_DB` | Required PostgreSQL database name for the Docker Compose stack |
 | `POSTGRES_USER` | Required PostgreSQL username for the Docker Compose stack and API container |
 | `POSTGRES_PASSWORD` | Required PostgreSQL password for the Docker Compose stack and API container |
+| `GITHUB_PERSONAL_ACCESS_TOKEN` | Optional GitHub personal access token used by the GitHub MCP server when that MCP is enabled |
 | `SHARPCLAW_JWT_SECRET` | Required JWT signing secret used for API authentication |
 | `SHARPCLAW_DB_CONNECTION` | Required for non-Docker API runs unless `ConnectionStrings:DefaultConnection` is supplied another way |
 | `SHARPCLAW_WORKSPACE` | Host-side path mounted into the Docker container as `/workspace` (Docker Compose and service installs only; not read by the API directly) |
@@ -223,6 +229,7 @@ POSTGRES_DB=sharpclaw
 POSTGRES_USER=sharpclaw
 POSTGRES_PASSWORD=change-me
 SHARPCLAW_JWT_SECRET=replace-with-a-random-secret-at-least-32-characters-long
+GITHUB_PERSONAL_ACCESS_TOKEN=
 ```
 
 Notes:
@@ -230,6 +237,8 @@ Notes:
 - `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` are required for Docker Compose runs and are used to configure both the PostgreSQL container and the API container's default connection string
 - Direct `dotnet run` execution also requires a database connection via `SHARPCLAW_DB_CONNECTION` or `ConnectionStrings:DefaultConnection`; the API no longer falls back to a hard-coded local database credential set
 - `SHARPCLAW_JWT_SECRET` is required whenever the API runs; use a random string with at least 32 characters
+- `GITHUB_PERSONAL_ACCESS_TOKEN` is only needed if you want to enable the seeded GitHub MCP
+- Docker Compose mounts `${HOME}/knowledge` into the API container at `/knowledge` for the seeded `knowledge-base` MCP
 - LLM provider API keys are managed in `Configure > Backends` and stored in PostgreSQL
 - Telegram settings (enabled, bot token, allowlists) are managed in `Configure > Telegram` and stored in PostgreSQL
 - `SHARPCLAW_WORKSPACE` is only used by Docker Compose and the service install script to set up the workspace directory; the workspace path exposed to the filesystem MCP server is configured in `Configure > Settings` at runtime
@@ -440,10 +449,13 @@ Key variables for a local run (see [Environment Variables](#environment-variable
 | `POSTGRES_USER` | PostgreSQL role name |
 | `POSTGRES_PASSWORD` | PostgreSQL role password |
 | `SHARPCLAW_DB_CONNECTION` | Full connection string – the backend script constructs this automatically from `POSTGRES_*` if it is not set |
+| `GITHUB_PERSONAL_ACCESS_TOKEN` | Needed only if you want to enable the seeded GitHub MCP |
 | `SHARPCLAW_WORKSPACE` | Host-side path mounted as the default workspace directory (service install only; workspace is configured at runtime via `Configure > Settings`) |
+| `SHARPCLAW_KNOWLEDGE_BASE` | Optional override for the seeded `knowledge-base` MCP path; service installs default this to `/var/lib/sharpclaw/knowledge` |
 | `SHARPCLAW_JWT_SECRET` | Required JWT signing secret for API authentication |
 
 After startup, configure backend provider keys in `Configure > Backends`.
+The generated service env file only carries runtime and MCP-level environment values; backend provider credentials are no longer written there.
 
 ### Starting the Backend
 

--- a/SharpClaw.Api/Services/SessionRuntimeService.cs
+++ b/SharpClaw.Api/Services/SessionRuntimeService.cs
@@ -61,6 +61,14 @@ public sealed class SessionRuntimeService(
             store.DeleteSession(sessionId);
             return new ApiResponse<IApiPayload>(StatusCodes.Status409Conflict, new ErrorResponse(ex.Message));
         }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to initialize session runner for agent '{AgentId}'", agentRecord.Slug);
+            store.DeleteSession(sessionId);
+            return new ApiResponse<IApiPayload>(
+                StatusCodes.Status500InternalServerError,
+                new ErrorResponse($"Failed to initialize agent '{agentRecord.Slug}'. Check MCP configuration and runtime dependencies."));
+        }
 
         return new ApiResponse<IApiPayload>(
             StatusCodes.Status200OK,
@@ -134,6 +142,13 @@ public sealed class SessionRuntimeService(
             catch (InvalidOperationException ex)
             {
                 return new ApiResponse<IApiPayload>(StatusCodes.Status409Conflict, new ErrorResponse(ex.Message));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to initialize session runner for agent '{AgentId}'", agentRecord.Slug);
+                return new ApiResponse<IApiPayload>(
+                    StatusCodes.Status500InternalServerError,
+                    new ErrorResponse($"Failed to initialize agent '{agentRecord.Slug}'. Check MCP configuration and runtime dependencies."));
             }
 
             _runners[sessionId] = runner;

--- a/SharpClaw.Core/AgentRunner.cs
+++ b/SharpClaw.Core/AgentRunner.cs
@@ -167,7 +167,7 @@ public sealed class AgentRunner : IAsyncDisposable
             $"Unknown backend '{persona.Backend}'. Register a backendFactory to support it.");
     }
 
-    private static string CreateToolName(string mcpSlug, string rawToolName) => $"{mcpSlug}.{rawToolName}";
+    private static string CreateToolName(string mcpSlug, string rawToolName) => $"{mcpSlug}-{rawToolName}";
 
     public async ValueTask DisposeAsync()
     {

--- a/SharpClaw.Core/McpServerRegistry.cs
+++ b/SharpClaw.Core/McpServerRegistry.cs
@@ -8,7 +8,9 @@ namespace SharpClaw.Core;
 /// </summary>
 public static class McpServerRegistry
 {
-    private const string AllowedDirsPlaceholder = "${SHARPCLAW_ALLOWED_DIRS}";
+    private const string WorkspacePathPlaceholder = "${WORKSPACE_PATH}";
+    private const string LegacyAllowedDirsPlaceholder = "${SHARPCLAW_ALLOWED_DIRS}";
+    private const string KnowledgeBasePlaceholder = "${SHARPCLAW_KNOWLEDGE_BASE}";
     private static readonly Regex EnvVarPattern = new(@"\$\{(?<name>[A-Z0-9_]+)\}", RegexOptions.Compiled);
 
     private static string[] ResolveAllowedDirs(string? workspacePath)
@@ -17,6 +19,22 @@ public static class McpServerRegistry
             return [workspacePath.Trim()];
 
         return [Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)];
+    }
+
+    private static string ResolveKnowledgeBaseDir()
+    {
+        var configuredPath = Environment.GetEnvironmentVariable("SHARPCLAW_KNOWLEDGE_BASE");
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+            return configuredPath.Trim();
+
+        if (Directory.Exists("/knowledge"))
+            return "/knowledge";
+
+        var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(homeDir))
+            return Path.Combine(homeDir, "knowledge");
+
+        return Path.Combine(Environment.CurrentDirectory, "knowledge");
     }
 
     /// <summary>
@@ -41,9 +59,16 @@ public static class McpServerRegistry
 
         foreach (var arg in rawArgs)
         {
-            if (string.Equals(arg, AllowedDirsPlaceholder, StringComparison.Ordinal))
+            if (string.Equals(arg, WorkspacePathPlaceholder, StringComparison.Ordinal)
+                || string.Equals(arg, LegacyAllowedDirsPlaceholder, StringComparison.Ordinal))
             {
                 expanded.AddRange(ResolveAllowedDirs(workspacePath));
+                continue;
+            }
+
+            if (string.Equals(arg, KnowledgeBasePlaceholder, StringComparison.Ordinal))
+            {
+                expanded.Add(ResolveKnowledgeBaseDir());
                 continue;
             }
 

--- a/SharpClaw.Core/SessionStore.cs
+++ b/SharpClaw.Core/SessionStore.cs
@@ -467,7 +467,7 @@ public sealed class SessionStore : IDisposable
             Name: "Filesystem",
             Description: "Read and write files from allowed workspace directories.",
             Command: "npx",
-            Args: ["-y", "@modelcontextprotocol/server-filesystem", "${SHARPCLAW_ALLOWED_DIRS}"],
+            Args: ["-y", "@modelcontextprotocol/server-filesystem", "${WORKSPACE_PATH}"],
             IsEnabled: true),
 
         new McpServerRecord(
@@ -484,15 +484,15 @@ public sealed class SessionStore : IDisposable
             Description: "Interact with GitHub repositories, issues, and pull requests.",
             Command: "npx",
             Args: ["-y", "@modelcontextprotocol/server-github"],
-            IsEnabled: true),
+            IsEnabled: false),
 
         new McpServerRecord(
             Slug: "knowledge-base",
             Name: "Knowledge Base",
-            Description: "Read and write journal entries, daily notes, meeting notes, and personal notes in ~/knowledge.",
+            Description: "Read and write journal entries, daily notes, meeting notes, and personal notes in the configured knowledge base directory.",
             Command: "npx",
-            Args: ["-y", "@modelcontextprotocol/server-filesystem", "${HOME}/knowledge"],
-            IsEnabled: true),
+            Args: ["-y", "@modelcontextprotocol/server-filesystem", "${SHARPCLAW_KNOWLEDGE_BASE}"],
+            IsEnabled: false),
     ];
 
     private static readonly IReadOnlyList<AgentRecord> BuiltInAgents =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
         condition: service_healthy
     volumes:
       - ${SHARPCLAW_WORKSPACE:-./workspace}:/workspace
+      - ${HOME}/knowledge:/knowledge
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/api/health"]
       interval: 10s
@@ -34,12 +35,10 @@ services:
       retries: 6
       start_period: 30s
     environment:
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
       - SHARPCLAW_JWT_SECRET=${SHARPCLAW_JWT_SECRET:?SHARPCLAW_JWT_SECRET is required}
-      - GITHUB_COPILOT_TOKEN=${GITHUB_COPILOT_TOKEN}
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - ConnectionStrings__DefaultConnection=Host=postgres;Database=${POSTGRES_DB:?POSTGRES_DB is required};Username=${POSTGRES_USER:?POSTGRES_USER is required};Password=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
-      - SHARPCLAW_WORKSPACE=/workspace
+      - SHARPCLAW_KNOWLEDGE_BASE=/knowledge
 
   web:
     build: SharpClaw.Web

--- a/scripts/install-service-linux.sh
+++ b/scripts/install-service-linux.sh
@@ -268,15 +268,13 @@ info "Writing environment file to $ENV_FILE ..."
     # Database
     echo "SHARPCLAW_DB_CONNECTION=${SHARPCLAW_DB_CONNECTION:-}"
 
-    # AI keys (write even if empty so the file is a complete reference)
-    echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}"
-    echo "OPENAI_API_KEY=${OPENAI_API_KEY:-}"
-    echo "OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}"
-    echo "GITHUB_COPILOT_TOKEN=${GITHUB_COPILOT_TOKEN:-}"
+    # MCP / integration credentials
+    echo "GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN:-}"
 
     # Auth / workspace
     echo "SHARPCLAW_JWT_SECRET=${SHARPCLAW_JWT_SECRET:-}"
     echo "SHARPCLAW_WORKSPACE=${SHARPCLAW_WORKSPACE:-/opt/sharpclaw/workspace}"
+    echo "SHARPCLAW_KNOWLEDGE_BASE=${SHARPCLAW_KNOWLEDGE_BASE:-/var/lib/sharpclaw/knowledge}"
 
     # Telegram worker service integration
     echo "SHARPCLAW_API_URL=${SHARPCLAW_API_URL:-http://127.0.0.1:5000}"
@@ -296,6 +294,11 @@ WORKSPACE_DIR="${SHARPCLAW_WORKSPACE:-/opt/sharpclaw/workspace}"
 mkdir -p "$WORKSPACE_DIR"
 chown "$INSTALL_USER":"$INSTALL_USER" "$WORKSPACE_DIR"
 info "Workspace directory: $WORKSPACE_DIR"
+
+KNOWLEDGE_DIR="${SHARPCLAW_KNOWLEDGE_BASE:-/var/lib/sharpclaw/knowledge}"
+mkdir -p "$KNOWLEDGE_DIR"
+chown "$INSTALL_USER":"$INSTALL_USER" "$KNOWLEDGE_DIR"
+info "Knowledge base directory: $KNOWLEDGE_DIR"
 
 TELEGRAM_MAPPING_FILE="${TELEGRAM__MAPPINGSTOREPATH:-/var/lib/sharpclaw/telegram-session-mappings.json}"
 TELEGRAM_MAPPING_DIR="/var/lib/sharpclaw"


### PR DESCRIPTION
This pull request introduces environment variable and configuration changes to support new MCP (Model Context Protocol) server behaviors, especially for the GitHub and knowledge-base MCPs. It improves flexibility for deployment environments, enhances error handling, and updates documentation and defaults for clarity and security.

**Key changes:**

### 1. Environment and Configuration Updates

- Added `GITHUB_PERSONAL_ACCESS_TOKEN` and `SHARPCLAW_KNOWLEDGE_BASE` environment variables to support the GitHub and knowledge-base MCPs, with appropriate defaults and documentation in `.env.example`, `README.md`, `docker-compose.yml`, and `install-service-linux.sh`. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R216) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R232-R241) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R452-R458) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R30-R41) [[6]](diffhunk://#diff-cd6b6c89aa078789901e403ec43d48db4d00bec88cb46313d86b480a31a7e5eaL271-R277) [[7]](diffhunk://#diff-cd6b6c89aa078789901e403ec43d48db4d00bec88cb46313d86b480a31a7e5eaR298-R302)

- Docker Compose and service install scripts now mount and initialize the knowledge base directory as needed, ensuring consistent behavior across deployment types. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R30-R41) [[2]](diffhunk://#diff-cd6b6c89aa078789901e403ec43d48db4d00bec88cb46313d86b480a31a7e5eaR298-R302)

### 2. MCP Server and Tooling Behavior

- The seeded `github` and `knowledge-base` MCPs now start disabled by default, requiring explicit environment configuration before enabling. The knowledge-base MCP path is now resolved dynamically based on environment and deployment context. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R113-R117) [[2]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L487-R495)

- Updated the built-in MCP server records to use new environment variable placeholders (e.g., `${WORKSPACE_PATH}`, `${SHARPCLAW_KNOWLEDGE_BASE}`) and improved the knowledge-base MCP description for clarity. [[1]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L470-R470) [[2]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L487-R495)

- Changed the tool naming convention in `AgentRunner` from `mcpSlug.rawToolName` to `mcpSlug-rawToolName` for consistency.

### 3. Codebase Robustness and Error Handling

- Improved error handling in `SessionRuntimeService` to log and return user-friendly errors when agent initialization fails, including MCP misconfiguration or missing dependencies. [[1]](diffhunk://#diff-6416da251a915e49149b3d90104cb3a4f6ebf05d1123c1a1db6877d3f95ab009R64-R71) [[2]](diffhunk://#diff-6416da251a915e49149b3d90104cb3a4f6ebf05d1123c1a1db6877d3f95ab009R146-R152)

### 4. Internal Refactoring

- Refactored MCP server argument expansion to support new placeholders and resolve the knowledge base directory dynamically, ensuring backward compatibility with legacy placeholders. [[1]](diffhunk://#diff-fa07051221377acd0fc7ac0aad725d6e66d5da1164431e12e8ddf3126fa3aaa9L11-R13) [[2]](diffhunk://#diff-fa07051221377acd0fc7ac0aad725d6e66d5da1164431e12e8ddf3126fa3aaa9R24-R39) [[3]](diffhunk://#diff-fa07051221377acd0fc7ac0aad725d6e66d5da1164431e12e8ddf3126fa3aaa9L44-R74)

These changes collectively make MCP configuration more robust, flexible, and easier to manage across different environments and deployment methods.