### PR TITLE
Fix agent routing bug from telegram channel

### DIFF
--- a/SharpClaw.Api/ApiMapper.cs
+++ b/SharpClaw.Api/ApiMapper.cs
@@ -5,7 +5,7 @@ namespace SharpClaw.Api;
 
 internal static class ApiMapper
 {
-    internal const string AdeAgentId = "ade.agent.md";
+    internal const string AdeAgentId = "ade";
 
     internal static string CreateAgentId(string name)
     {


### PR DESCRIPTION
This pull request makes a small but important change to the constant value used for agent identification in the `ApiMapper` class. The string assigned to `AdeAgentId` has been simplified from `"ade.agent.md"` to just `"ade"`.

* Changed the value of the `AdeAgentId` constant in `ApiMapper` from `"ade.agent.md"` to `"ade"` to simplify agent identification.