### PR TITLE
Fix telegram ignoring SSE events

### DIFF
--- a/SharpClaw.Telegram/SharpClawApiClient.cs
+++ b/SharpClaw.Telegram/SharpClawApiClient.cs
@@ -114,6 +114,7 @@ public sealed class SharpClawApiClient(HttpClient httpClient, ILogger<SharpClawA
         using var reader = new StreamReader(stream);
 
         string? currentEventType = null;
+        var statuses = new List<string>();
 
         string? line;
         while ((line = await reader.ReadLineAsync(ct)) is not null)
@@ -128,12 +129,39 @@ public sealed class SharpClawApiClient(HttpClient httpClient, ILogger<SharpClawA
                 var data = line[6..];
                 switch (currentEventType)
                 {
+                    case "status":
+                        try
+                        {
+                            using var doc = JsonDocument.Parse(data);
+                            if (doc.RootElement.TryGetProperty("message", out var messageEl))
+                            {
+                                var statusText = messageEl.GetString();
+                                if (!string.IsNullOrWhiteSpace(statusText))
+                                    statuses.Add(statusText.Trim());
+                            }
+                        }
+                        catch (JsonException ex)
+                        {
+                            logger.LogWarning(ex, "Failed to parse status event payload");
+                        }
+                        break;
+
                     case "done":
                         try
                         {
                             using var doc = JsonDocument.Parse(data);
                             if (doc.RootElement.TryGetProperty("content", out var contentEl))
-                                return contentEl.GetString() ?? string.Empty;
+                            {
+                                var content = contentEl.GetString() ?? string.Empty;
+                                if (statuses.Count == 0)
+                                    return content;
+
+                                var statusPrefix = string.Join('\n', statuses.Select(message => $"[{message}]"));
+                                if (string.IsNullOrWhiteSpace(content))
+                                    return statusPrefix;
+
+                                return $"{statusPrefix}\n\n{content}";
+                            }
                         }
                         catch (JsonException ex)
                         {


### PR DESCRIPTION
This pull request updates the `ConsumeStreamAsync` method in `SharpClawApiClient.cs` to improve how status events are handled and included in the final output. Now, status messages received during the stream are collected and prepended to the final content returned when the stream is done.

**Enhancements to status event handling:**

* Added collection of status messages from "status" events during the stream and prepended them to the final content returned by the "done" event, formatting each status as `[message]`. If there is no content, only the statuses are returned.
* Introduced a `statuses` list to accumulate status messages as the stream is processed.