### PR TITLE
BUG: Incorrect agent slug in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ Example response:
 ```json
 [
 	{
-		"id": "ade.agent.md",
+		"id": "ade",
 		"name": "Ade",
 		"description": "A general assistant who helps directly and hands work to a better-fit specialist when needed.",
 		"backend": "anthropic",
@@ -805,7 +805,7 @@ Example request:
 
 ```json
 {
-	"agentId": "ade.agent.md"
+	"agentId": "ade"
 }
 ```
 
@@ -815,7 +815,7 @@ Example response:
 {
 	"sessionId": "abc123def456",
 	"persona": "Ade",
-	"agentId": "ade.agent.md"
+	"agentId": "ade"
 }
 ```
 

--- a/SharpClaw.Web/src/AgentConfigView.tsx
+++ b/SharpClaw.Web/src/AgentConfigView.tsx
@@ -282,7 +282,7 @@ function buildPermissionGroups(rows: PermissionRow[], mcps: string[]): Permissio
 }
 
 function isAdeAgent(agent: Pick<AgentDefinition, 'id' | 'name'>): boolean {
-  return agent.id === 'ade.agent.md' || agent.name.trim().toLowerCase() === 'ade';
+  return agent.id === 'ade' || agent.id === 'ade.agent.md' || agent.name.trim().toLowerCase() === 'ade';
 }
 
 export function AgentConfigView({ onMenuClick }: AgentConfigViewProps) {

--- a/SharpClaw.Web/src/useChat.ts
+++ b/SharpClaw.Web/src/useChat.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import type { Session, ChatMessage, PersistedSession, PersistedStreamItem, StreamItem, AgentEvent, ToolResultEvent } from './types';
 import { createSession, deleteSession as deletePersistedSession, fetchSession, fetchSessions, sendMessage, streamEvents } from './api';
 
-const DEFAULT_AGENT_ID = 'ade.agent.md';
+const DEFAULT_AGENT_ID = 'ade';
 const DEFAULT_PERSONA_NAME = 'Ade';
 
 export interface SessionState {


### PR DESCRIPTION
This pull request updates the default agent identifier for "Ade" throughout the codebase and documentation to use the simpler `ade` string instead of `ade.agent.md`. It also ensures that both identifiers are recognized for backward compatibility in the UI logic.

Documentation updates:
* Updated all example requests and responses in `README.md` to use `"ade"` as the agent ID instead of `"ade.agent.md"`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L808-R808) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L818-R818) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L669-R669)

Frontend logic updates:
* Changed the default agent ID in `SharpClaw.Web/src/useChat.ts` to `"ade"`, aligning the code with the new identifier.
* Updated the `isAdeAgent` function in `SharpClaw.Web/src/AgentConfigView.tsx` to recognize both `"ade"` and `"ade.agent.md"` as valid IDs for Ade, maintaining compatibility with previous data.