### PR TITLE
Add auto-approve permissions for filesystem edit and directory actions for Cody agent

### DIFF
--- a/SharpClaw.Core/SessionStore.cs
+++ b/SharpClaw.Core/SessionStore.cs
@@ -417,6 +417,8 @@ public sealed class SessionStore : IDisposable
                 { "filesystem.search_*", "auto_approve" },
                 { "filesystem.create_*", "auto_approve" },
                 { "filesystem.write_*", "auto_approve" },
+                { "filesystem.edit_*", "auto_approve" },
+                { "filesystem.directory_*", "auto_approve" },
                 { "filesystem.delete_*", "ask" },
                 { "github.read_*", "auto_approve" },
                 { "github.search_*", "auto_approve" },


### PR DESCRIPTION
This pull request makes a small update to the action approval policy in `SessionStore.cs` by auto-approving additional filesystem operations.

- Policy changes for filesystem actions:
  * Added `filesystem.edit_*` and `filesystem.directory_*` to the list of auto-approved actions, allowing these operations to proceed without manual approval.