### PR TITLE
Fix type conversion for ExecuteScalar return values in SessionStore

### DIFF
--- a/SharpClaw.Core/SessionStore.cs
+++ b/SharpClaw.Core/SessionStore.cs
@@ -1434,7 +1434,7 @@ public sealed class SessionStore : IDisposable
             """;
         cmd.Parameters.AddWithValue("provider", provider);
         cmd.Parameters.AddWithValue("date", date);
-        return (long)(cmd.ExecuteScalar() ?? 0L);
+        return Convert.ToInt64(cmd.ExecuteScalar() ?? 0L);
     }
 
     /// <summary>
@@ -1451,7 +1451,7 @@ public sealed class SessionStore : IDisposable
             """;
         cmd.Parameters.AddWithValue("agent_slug", agentSlug);
         cmd.Parameters.AddWithValue("date", date);
-        return (long)(cmd.ExecuteScalar() ?? 0L);
+        return Convert.ToInt64(cmd.ExecuteScalar() ?? 0L);
     }
 
     /// <summary>
@@ -1534,7 +1534,7 @@ public sealed class SessionStore : IDisposable
             dataPoints.Add(new TokenUsageDataPoint(
                 Bucket: reader.GetString(0),
                 AgentSlug: reader.GetString(1),
-                TotalTokens: reader.GetInt64(2)));
+                TotalTokens: Convert.ToInt64(reader.GetValue(2))));
         }
 
         return dataPoints;


### PR DESCRIPTION
This pull request makes minor improvements to type conversion and data handling in the `SharpClaw.Core/SessionStore.cs` file, specifically around reading and returning token usage data.

- Data conversion consistency:
  * Replaced direct casts to `long` with `Convert.ToInt64` when returning results from `cmd.ExecuteScalar()`, ensuring safer and more robust type conversion when reading database values. [[1]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L1437-R1437) [[2]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L1454-R1454)
  * Updated the construction of `TokenUsageDataPoint` to use `Convert.ToInt64(reader.GetValue(2))` instead of `reader.GetInt64(2)`, improving compatibility with varying data types returned by the database.