### PR TITLE
Add URL support for MCPs and update related validation and storage logic

### DIFF
--- a/SharpClaw.Api/ApiMapper.cs
+++ b/SharpClaw.Api/ApiMapper.cs
@@ -107,7 +107,8 @@ internal static class ApiMapper
             mcp.Command,
             mcp.Args,
             mcp.IsEnabled,
-            linkedAgentCount);
+            linkedAgentCount,
+            mcp.Url);
 
     internal static BackendModelsResponse ToBackendModelsDto(
         IReadOnlyList<BackendModelInfo> models,
@@ -169,9 +170,10 @@ internal static class ApiMapper
         Slug: slugOverride ?? req.Slug!.Trim(),
         Name: req.Name!.Trim(),
         Description: req.Description!.Trim(),
-        Command: req.Command!.Trim(),
+        Command: (req.Command ?? string.Empty).Trim(),
         Args: NormalizeStringList(req.Args),
-        IsEnabled: req.IsEnabled ?? true);
+        IsEnabled: req.IsEnabled ?? true,
+        Url: string.IsNullOrWhiteSpace(req.Url) ? null : req.Url.Trim());
 
     internal static string BuildDirectResponseSystemPrompt(AgentRecord agentRecord)
     {

--- a/SharpClaw.Api/ApiValidator.cs
+++ b/SharpClaw.Api/ApiValidator.cs
@@ -45,8 +45,20 @@ internal static class ApiValidator
             return "name is required.";
         if (string.IsNullOrWhiteSpace(req.Description))
             return "description is required.";
-        if (string.IsNullOrWhiteSpace(req.Command))
-            return "command is required.";
+
+        var hasCommand = !string.IsNullOrWhiteSpace(req.Command);
+        var hasUrl = !string.IsNullOrWhiteSpace(req.Url);
+
+        if (!hasCommand && !hasUrl)
+            return "Either command or url is required.";
+        if (hasCommand && hasUrl)
+            return "command and url cannot both be set. Use command for stdio MCPs or url for remote HTTP/SSE MCPs.";
+
+        if (hasUrl && !Uri.TryCreate(req.Url, UriKind.Absolute, out var uri))
+            return "url must be a valid absolute URI (e.g. https://example.com/sse).";
+        else if (hasUrl && Uri.TryCreate(req.Url, UriKind.Absolute, out var parsedUri)
+                 && parsedUri.Scheme != "http" && parsedUri.Scheme != "https")
+            return "url must use the http or https scheme.";
 
         return null;
     }

--- a/SharpClaw.Api/Models/ApiContracts.cs
+++ b/SharpClaw.Api/Models/ApiContracts.cs
@@ -52,7 +52,8 @@ public sealed record McpDto(
     string Command,
     IReadOnlyList<string> Args,
     bool IsEnabled,
-    int LinkedAgentCount) : IApiPayload;
+    int LinkedAgentCount,
+    string? Url) : IApiPayload;
 
 public sealed record BackendModelDto(string Id, string DisplayName);
 
@@ -180,7 +181,8 @@ public sealed record McpDefinitionRequest(
     string? Description,
     string? Command,
     List<string>? Args,
-    bool? IsEnabled);
+    bool? IsEnabled,
+    string? Url);
 
 public sealed record ProviderDailyUsageDto(
     string Provider,

--- a/SharpClaw.Core/AgentRunner.cs
+++ b/SharpClaw.Core/AgentRunner.cs
@@ -58,21 +58,19 @@ public sealed class AgentRunner : IAsyncDisposable
 
         foreach (var server in _mcpServers)
         {
-            var launch = McpServerRegistry.ResolveLaunch(server, _workspacePath);
+            var displayInfo = server.IsRemote ? server.Url! : McpServerRegistry.ResolveLaunch(server, _workspacePath).DisplayCommand;
+
             _logger?.LogInformation(
-                "Starting MCP {McpSlug} ({McpName}) with command {McpCommand}.",
+                server.IsRemote
+                    ? "Connecting to remote MCP {McpSlug} ({McpName}) at {McpEndpoint}."
+                    : "Starting MCP {McpSlug} ({McpName}) with command {McpEndpoint}.",
                 server.Slug,
                 server.Name,
-                launch.DisplayCommand);
+                displayInfo);
 
             try
             {
-                var transport = new StdioClientTransport(new StdioClientTransportOptions
-                {
-                    Command = launch.Command,
-                    Arguments = launch.Arguments.ToList(),
-                    Name = server.Slug,
-                });
+                var transport = McpServerRegistry.Resolve(server, _workspacePath);
 
                 var client = await McpClient.CreateAsync(transport, cancellationToken: ct);
                 _mcpClients.Add(client);
@@ -88,7 +86,7 @@ public sealed class AgentRunner : IAsyncDisposable
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 throw new IOException(
-                    $"Failed to initialize MCP '{server.Slug}' using {launch.DisplayCommand}. {ex.Message}",
+                    $"Failed to initialize MCP '{server.Slug}' using {displayInfo}. {ex.Message}",
                     ex);
             }
         }

--- a/SharpClaw.Core/McpServerRecord.cs
+++ b/SharpClaw.Core/McpServerRecord.cs
@@ -9,4 +9,11 @@ public sealed record McpServerRecord(
     string Description,
     string Command,
     IReadOnlyList<string> Args,
-    bool IsEnabled);
+    bool IsEnabled,
+    string? Url = null)
+{
+    /// <summary>
+    /// True when this MCP is configured as a remote HTTP/SSE server rather than a local stdio process.
+    /// </summary>
+    public bool IsRemote => !string.IsNullOrWhiteSpace(Url);
+}

--- a/SharpClaw.Core/McpServerRegistry.cs
+++ b/SharpClaw.Core/McpServerRegistry.cs
@@ -41,9 +41,20 @@ public static class McpServerRegistry
 
     /// <summary>
     /// Returns an <see cref="IClientTransport"/> for a stored MCP server definition.
+    /// Uses <see cref="HttpClientTransport"/> for remote (URL-based) servers, and
+    /// <see cref="StdioClientTransport"/> for local (command-based) servers.
     /// </summary>
     public static IClientTransport Resolve(McpServerRecord server, string? workspacePath = null)
     {
+        if (server.IsRemote)
+        {
+            return new HttpClientTransport(new HttpClientTransportOptions
+            {
+                Endpoint = new Uri(server.Url!),
+                Name = server.Slug,
+            });
+        }
+
         var launch = ResolveLaunch(server, workspacePath);
 
         return new StdioClientTransport(new StdioClientTransportOptions
@@ -56,6 +67,9 @@ public static class McpServerRegistry
 
     public static McpLaunchInfo ResolveLaunch(McpServerRecord server, string? workspacePath = null)
     {
+        if (server.IsRemote)
+            return new McpLaunchInfo(string.Empty, [], server.Url!);
+
         if (string.IsNullOrWhiteSpace(server.Command))
             throw new ArgumentException($"MCP '{server.Slug}' has no command configured.");
 

--- a/SharpClaw.Core/SessionStore.cs
+++ b/SharpClaw.Core/SessionStore.cs
@@ -202,6 +202,7 @@ public sealed class SessionStore : IDisposable
             ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
             ALTER TABLE backend_settings ADD COLUMN IF NOT EXISTS daily_token_limit BIGINT NOT NULL DEFAULT 1000000;
             ALTER TABLE agents ADD COLUMN IF NOT EXISTS daily_token_limit BIGINT NULL;
+            ALTER TABLE mcps ADD COLUMN IF NOT EXISTS url TEXT NULL;
 
             CREATE TABLE IF NOT EXISTS token_usage_alerts (
                 id SERIAL PRIMARY KEY,
@@ -227,8 +228,8 @@ public sealed class SessionStore : IDisposable
         {
             using var cmd = conn.CreateCommand();
             cmd.CommandText = """
-                INSERT INTO mcps (slug, name, description, command, args, is_enabled)
-                VALUES (@slug, @name, @description, @command, @args, @is_enabled)
+                INSERT INTO mcps (slug, name, description, command, args, is_enabled, url)
+                VALUES (@slug, @name, @description, @command, @args, @is_enabled, @url)
                 ON CONFLICT (slug) DO UPDATE
                 SET description = CASE
                         WHEN mcps.description = '' THEN EXCLUDED.description
@@ -241,6 +242,10 @@ public sealed class SessionStore : IDisposable
                     args = CASE
                         WHEN mcps.args = '[]'::jsonb THEN EXCLUDED.args
                         ELSE mcps.args
+                    END,
+                    url = CASE
+                        WHEN mcps.url IS NULL THEN EXCLUDED.url
+                        ELSE mcps.url
                     END
                 """;
             WriteMcpParameters(cmd, seed);
@@ -687,7 +692,7 @@ public sealed class SessionStore : IDisposable
         using var conn = _dataSource.OpenConnection();
         using var cmd = conn.CreateCommand();
         cmd.CommandText = """
-            SELECT slug, name, description, command, args::text, is_enabled
+            SELECT slug, name, description, command, args::text, is_enabled, url
             FROM mcps
             WHERE @include_disabled OR is_enabled = TRUE
             ORDER BY name
@@ -737,7 +742,7 @@ public sealed class SessionStore : IDisposable
         using var conn = _dataSource.OpenConnection();
         using var cmd = conn.CreateCommand();
         cmd.CommandText = """
-            SELECT slug, name, description, command, args::text, is_enabled
+            SELECT slug, name, description, command, args::text, is_enabled, url
             FROM mcps
             WHERE slug = @slug
             """;
@@ -752,8 +757,8 @@ public sealed class SessionStore : IDisposable
         using var conn = _dataSource.OpenConnection();
         using var cmd = conn.CreateCommand();
         cmd.CommandText = """
-            INSERT INTO mcps (slug, name, description, command, args, is_enabled)
-            VALUES (@slug, @name, @description, @command, @args, @is_enabled)
+            INSERT INTO mcps (slug, name, description, command, args, is_enabled, url)
+            VALUES (@slug, @name, @description, @command, @args, @is_enabled, @url)
             """;
         WriteMcpParameters(cmd, mcp);
         cmd.ExecuteNonQuery();
@@ -769,7 +774,8 @@ public sealed class SessionStore : IDisposable
                 description = @description,
                 command = @command,
                 args = @args,
-                is_enabled = @is_enabled
+                is_enabled = @is_enabled,
+                url = @url
             WHERE slug = @slug
             """;
         WriteMcpParameters(cmd, mcp with { Slug = slug });
@@ -1239,7 +1245,8 @@ public sealed class SessionStore : IDisposable
             Description: reader.GetString(2),
             Command: reader.GetString(3),
             Args: args,
-            IsEnabled: reader.GetBoolean(5));
+            IsEnabled: reader.GetBoolean(5),
+            Url: reader.IsDBNull(6) ? null : reader.GetString(6));
     }
 
     private static void WriteAgentParameters(NpgsqlCommand cmd, AgentRecord agent)
@@ -1264,6 +1271,7 @@ public sealed class SessionStore : IDisposable
         cmd.Parameters.AddWithValue("command", mcp.Command);
         cmd.Parameters.Add("args", NpgsqlDbType.Jsonb).Value = JsonSerializer.Serialize(mcp.Args, JsonOpts);
         cmd.Parameters.AddWithValue("is_enabled", mcp.IsEnabled);
+        cmd.Parameters.AddWithValue("url", (object?)mcp.Url ?? DBNull.Value);
     }
 
     private static string? NormalizeOptionalString(string? value)

--- a/SharpClaw.Web/src/McpConfigView.tsx
+++ b/SharpClaw.Web/src/McpConfigView.tsx
@@ -14,6 +14,7 @@ function blankMcp(): McpUpsertRequest {
     command: 'npx',
     args: ['-y'],
     isEnabled: true,
+    url: null,
   };
 }
 
@@ -25,6 +26,7 @@ function toForm(mcp: McpDefinition): McpUpsertRequest {
     command: mcp.command,
     args: [...mcp.args],
     isEnabled: mcp.isEnabled,
+    url: mcp.url,
   };
 }
 
@@ -156,8 +158,9 @@ export function McpConfigView({ onMenuClick }: McpConfigViewProps) {
         slug: form.slug.trim(),
         name: form.name.trim(),
         description: form.description.trim(),
-        command: form.command.trim(),
-        args: parseArgs(argsText),
+        command: form.url ? '' : form.command.trim(),
+        args: form.url ? [] : parseArgs(argsText),
+        url: form.url ? form.url.trim() : null,
       };
 
       const saved = selectedMcp
@@ -284,8 +287,8 @@ export function McpConfigView({ onMenuClick }: McpConfigViewProps) {
                   <p className="agent-card-description">{mcp.description}</p>
 
                   <div className="agent-meta-grid">
-                    <span className="mcp-card-command">{mcp.command}</span>
-                    <span>{mcp.args.length} arg{mcp.args.length === 1 ? '' : 's'}</span>
+                    <span className="mcp-card-command">{mcp.url ?? mcp.command}</span>
+                    {!mcp.url && <span>{mcp.args.length} arg{mcp.args.length === 1 ? '' : 's'}</span>}
                     <span>{mcp.linkedAgentCount} linked agent{mcp.linkedAgentCount === 1 ? '' : 's'}</span>
                   </div>
 
@@ -362,25 +365,59 @@ export function McpConfigView({ onMenuClick }: McpConfigViewProps) {
               />
             </label>
 
-            <label>
-              <span>Command</span>
-              <input
-                value={form.command}
-                onChange={event => setForm(prev => ({ ...prev, command: event.target.value }))}
-                placeholder="npx"
-              />
-            </label>
+            <div className="agent-form-row two-up">
+              <label>
+                <span>Transport</span>
+                <select
+                  value={form.url !== null ? 'remote' : 'stdio'}
+                  onChange={event => {
+                    if (event.target.value === 'remote') {
+                      setForm(prev => ({ ...prev, url: '', command: '', args: [] }));
+                      setArgsText('[]');
+                    } else {
+                      setForm(prev => ({ ...prev, url: null, command: 'npx', args: ['-y'] }));
+                      setArgsText(formatArgs(['-y']));
+                    }
+                  }}
+                >
+                  <option value="stdio">Stdio (local command)</option>
+                  <option value="remote">Remote (HTTP/SSE URL)</option>
+                </select>
+              </label>
+            </div>
 
-            <label>
-              <span>Args (JSON Array)</span>
-              <textarea
-                className="json-textarea"
-                value={argsText}
-                onChange={event => setArgsText(event.target.value)}
-                rows={8}
-                placeholder={'[\n  "-y",\n  "@modelcontextprotocol/server-github"\n]'}
-              />
-            </label>
+            {form.url !== null ? (
+              <label>
+                <span>URL</span>
+                <input
+                  value={form.url}
+                  onChange={event => setForm(prev => ({ ...prev, url: event.target.value }))}
+                  placeholder="https://mcp.example.com/sse"
+                />
+              </label>
+            ) : (
+              <>
+                <label>
+                  <span>Command</span>
+                  <input
+                    value={form.command}
+                    onChange={event => setForm(prev => ({ ...prev, command: event.target.value }))}
+                    placeholder="npx"
+                  />
+                </label>
+
+                <label>
+                  <span>Args (JSON Array)</span>
+                  <textarea
+                    className="json-textarea"
+                    value={argsText}
+                    onChange={event => setArgsText(event.target.value)}
+                    rows={8}
+                    placeholder={'[\n  "-y",\n  "@modelcontextprotocol/server-github"\n]'}
+                  />
+                </label>
+              </>
+            )}
 
             <div className="mcp-selection-panel">
               <div className="agent-permissions-header">

--- a/SharpClaw.Web/src/types.ts
+++ b/SharpClaw.Web/src/types.ts
@@ -103,6 +103,7 @@ export interface McpDefinition {
     args: string[];
     isEnabled: boolean;
     linkedAgentCount: number;
+    url: string | null;
 }
 
 export interface McpUpsertRequest {
@@ -112,6 +113,7 @@ export interface McpUpsertRequest {
     command: string;
     args: string[];
     isEnabled: boolean;
+    url: string | null;
 }
 
 export interface TelegramSettings {


### PR DESCRIPTION
This pull request adds support for configuring MCPs (Model Context Protocol servers) as either local stdio processes or remote HTTP/SSE endpoints. The changes introduce a new `url` field for MCP definitions, update validation and the database schema, and enhance both backend and frontend logic to support and distinguish between these two MCP transport types.

**Backend changes:**

* **MCP transport type support:**
  - Added a `url` field to `McpServerRecord`, `McpDto`, and related API contracts, allowing MCPs to be defined as remote HTTP/SSE endpoints in addition to local command-based processes. The new `IsRemote` property distinguishes between the two. [[1]](diffhunk://#diff-ffe3d7d2251967ade82a4869f89a6a2fbbdb6ea8e5d7e9b5eb5b4c715c9f3f5bL12-R19) [[2]](diffhunk://#diff-21fd69f60e29a2db579a1a3803d4ee7ef64807208ad5b76f5c722b5f54396c9dL55-R56) [[3]](diffhunk://#diff-21fd69f60e29a2db579a1a3803d4ee7ef64807208ad5b76f5c722b5f54396c9dL183-R185)
  - The MCP validator now enforces that either `command` or `url` is set (but not both), and validates the `url` for correct scheme and format.

* **Database and data access updates:**
  - The `mcps` table schema is updated to include a nullable `url` column; all relevant queries and upsert logic are updated accordingly. [[1]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823R205) [[2]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L230-R232) [[3]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823R245-R248) [[4]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L690-R695) [[5]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L740-R745) [[6]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L755-R761) [[7]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L772-R778) [[8]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823L1242-R1249) [[9]](diffhunk://#diff-257f5a1bf3d308e4b4bef6c8e7fef465fb58cc1406a519bed42f4325fe458823R1274)

* **MCP initialization and transport selection:**
  - MCP startup logic now distinguishes between remote and local MCPs, using `HttpClientTransport` for remote endpoints and `StdioClientTransport` for local commands. Logging and error messages reflect the transport type. [[1]](diffhunk://#diff-a9615f51fd24fb2e8f51315e724357b09586f3eda445f7886f20cbf4952ce819L61-R73) [[2]](diffhunk://#diff-a9615f51fd24fb2e8f51315e724357b09586f3eda445f7886f20cbf4952ce819L91-R89) [[3]](diffhunk://#diff-fa07051221377acd0fc7ac0aad725d6e66d5da1164431e12e8ddf3126fa3aaa9R44-R57) [[4]](diffhunk://#diff-fa07051221377acd0fc7ac0aad725d6e66d5da1164431e12e8ddf3126fa3aaa9R70-R72)

**Frontend changes:**

* **MCP configuration UI:**
  - The MCP config view now lets users select between stdio (local command) and remote (HTTP/SSE URL) transport types, dynamically displaying relevant fields. The form and display logic are updated to handle the new `url` property. [[1]](diffhunk://#diff-fc0df5cc2b55d9752646149115b9fc7d28df26b510a8ab7e23027b3d324ab785R17) [[2]](diffhunk://#diff-fc0df5cc2b55d9752646149115b9fc7d28df26b510a8ab7e23027b3d324ab785R29) [[3]](diffhunk://#diff-fc0df5cc2b55d9752646149115b9fc7d28df26b510a8ab7e23027b3d324ab785L159-R163) [[4]](diffhunk://#diff-fc0df5cc2b55d9752646149115b9fc7d28df26b510a8ab7e23027b3d324ab785L287-R291) [[5]](diffhunk://#diff-fc0df5cc2b55d9752646149115b9fc7d28df26b510a8ab7e23027b3d324ab785R368-R399) [[6]](diffhunk://#diff-fc0df5cc2b55d9752646149115b9fc7d28df26b510a8ab7e23027b3d324ab785R419-R420)

* **Type definitions:**
  - `McpDefinition` and `McpUpsertRequest` types are updated to include the `url` field. [[1]](diffhunk://#diff-29f06e3121a7fa546e2020acf1ff25182f1c9e9d5d38048e14c3913df77bcbe7R106) [[2]](diffhunk://#diff-29f06e3121a7fa546e2020acf1ff25182f1c9e9d5d38048e14c3913df77bcbe7R116)