### PR TITLE
feat: add task editor page to web UI

### DIFF
--- a/SharpClaw.Web/src/App.tsx
+++ b/SharpClaw.Web/src/App.tsx
@@ -11,6 +11,7 @@ import ToolDetailPage from './pages/ToolDetailPage';
 import SkillListPage from './pages/SkillListPage';
 import SkillEditorPage from './pages/SkillEditorPage';
 import TaskListPage from './pages/TaskListPage';
+import TaskEditorPage from './pages/TaskEditorPage';
 import ProjectsPage from './pages/ProjectsPage';
 import ConfigPage from './pages/ConfigPage';
 import ExamplesPage from './pages/ExamplesPage';
@@ -33,6 +34,7 @@ export default function App() {
                 <Route path="/skills/new" element={<SkillEditorPage />} />
                 <Route path="/skills/:name" element={<SkillEditorPage />} />
                 <Route path="/tasks" element={<TaskListPage />} />
+                <Route path="/tasks/:id" element={<TaskEditorPage />} />
                 <Route path="/projects" element={<ProjectsPage />} />
                 <Route path="/config" element={<ConfigPage />} />
                 <Route path="/examples" element={<ExamplesPage />} />

--- a/SharpClaw.Web/src/api/tasks.ts
+++ b/SharpClaw.Web/src/api/tasks.ts
@@ -14,4 +14,39 @@ export interface ScheduledTaskSummary {
     prompt: string;
 }
 
+export interface ScheduledTaskDetail {
+    id: string;
+    agent: string;
+    description: string;
+    cron: string;
+    isOneOff: boolean;
+    channelKey: string;
+    channelType: string;
+    enabled: boolean;
+    created: string;
+    nextRun: string;
+    lastRun: string | null;
+    prompt: string;
+}
+
+export interface TaskUpdateRequest {
+    description?: string;
+    cron?: string;
+    prompt?: string;
+    enabled?: boolean;
+    isOneOff?: boolean;
+    agent?: string;
+}
+
 export const getTasks = () => apiFetch<ScheduledTaskSummary[]>('/tasks');
+
+export const getTask = (id: string) => apiFetch<ScheduledTaskDetail>(`/tasks/${id}`);
+
+export const updateTask = (id: string, data: TaskUpdateRequest) =>
+    apiFetch<{ id: string; message: string }>(`/tasks/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+
+export const deleteTask = (id: string) =>
+    apiFetch<void>(`/tasks/${id}`, { method: 'DELETE' });

--- a/SharpClaw.Web/src/pages/TaskEditorPage.tsx
+++ b/SharpClaw.Web/src/pages/TaskEditorPage.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+import Alert from '@mui/material/Alert';
+import Chip from '@mui/material/Chip';
+import SaveIcon from '@mui/icons-material/Save';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import Editor from '@monaco-editor/react';
+import { getTask, updateTask, deleteTask } from '../api/tasks';
+import type { ScheduledTaskDetail } from '../api/tasks';
+
+function formatDate(iso: string | null): string {
+    if (!iso) return '—';
+    return new Date(iso).toLocaleString();
+}
+
+export default function TaskEditorPage() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+
+    const [task, setTask] = useState<ScheduledTaskDetail | null>(null);
+    const [description, setDescription] = useState('');
+    const [cron, setCron] = useState('');
+    const [agent, setAgent] = useState('');
+    const [enabled, setEnabled] = useState(true);
+    const [isOneOff, setIsOneOff] = useState(false);
+    const [prompt, setPrompt] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState<string | null>(null);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!id) return;
+        getTask(id)
+            .then((t) => {
+                setTask(t);
+                setDescription(t.description);
+                setCron(t.cron);
+                setAgent(t.agent);
+                setEnabled(t.enabled);
+                setIsOneOff(t.isOneOff);
+                setPrompt(t.prompt);
+                setLoading(false);
+            })
+            .catch(() => {
+                setError('Task not found');
+                setLoading(false);
+            });
+    }, [id]);
+
+    const handleSave = async () => {
+        try {
+            setError(null);
+            setSuccess(null);
+            await updateTask(id!, {
+                description,
+                cron,
+                prompt,
+                enabled,
+                isOneOff,
+                agent,
+            });
+            setSuccess('Task saved successfully.');
+        } catch (e: unknown) {
+            setError(e instanceof Error ? e.message : 'Save failed');
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!id) return;
+        await deleteTask(id);
+        navigate('/tasks');
+    };
+
+    if (loading) {
+        return (
+            <Box>
+                <Typography color="text.secondary">Loading…</Typography>
+            </Box>
+        );
+    }
+
+    if (!task) {
+        return (
+            <Box>
+                <Alert severity="error">Task not found.</Alert>
+                <Button sx={{ mt: 2 }} onClick={() => navigate('/tasks')}>Back to Tasks</Button>
+            </Box>
+        );
+    }
+
+    return (
+        <Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+                    <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/tasks')} size="small">
+                        Tasks
+                    </Button>
+                    <Typography variant="h5" sx={{ fontFamily: 'monospace' }}>{id}</Typography>
+                    <Chip
+                        label={enabled ? 'Active' : 'Disabled'}
+                        color={enabled ? 'success' : 'default'}
+                        size="small"
+                    />
+                </Stack>
+                <Stack direction="row" spacing={1}>
+                    <Button variant="contained" startIcon={<SaveIcon />} onClick={handleSave}>
+                        Save
+                    </Button>
+                    <Button variant="outlined" color="error" startIcon={<DeleteIcon />} onClick={() => setDeleteOpen(true)}>
+                        Delete
+                    </Button>
+                </Stack>
+            </Box>
+
+            {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+            {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
+
+            <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+                <Stack spacing={2.5}>
+                    <TextField
+                        label="Description"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        fullWidth
+                        size="small"
+                    />
+                    <Stack direction="row" spacing={2}>
+                        <TextField
+                            label="Cron Expression"
+                            value={cron}
+                            onChange={(e) => setCron(e.target.value)}
+                            size="small"
+                            sx={{ width: 220 }}
+                            helperText="5-field standard cron (min hour dom mon dow)"
+                        />
+                        <TextField
+                            label="Agent"
+                            value={agent}
+                            onChange={(e) => setAgent(e.target.value)}
+                            size="small"
+                            sx={{ width: 200 }}
+                        />
+                    </Stack>
+                    <Stack direction="row" spacing={3} sx={{ alignItems: 'center' }}>
+                        <FormControlLabel
+                            control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
+                            label="Enabled"
+                        />
+                        <FormControlLabel
+                            control={<Switch checked={isOneOff} onChange={(e) => setIsOneOff(e.target.checked)} />}
+                            label="One-off (delete after run)"
+                        />
+                    </Stack>
+                    <Stack direction="row" spacing={3}>
+                        <Typography variant="caption" color="text.secondary">
+                            Channel: {task.channelType} ({task.channelKey})
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            Created: {formatDate(task.created)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            Next run: {formatDate(task.nextRun)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            Last run: {formatDate(task.lastRun)}
+                        </Typography>
+                    </Stack>
+                </Stack>
+            </Paper>
+
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>Prompt</Typography>
+            <Paper variant="outlined" sx={{ height: 'calc(100vh - 480px)', minHeight: 200, overflow: 'hidden' }}>
+                <Editor
+                    height="100%"
+                    defaultLanguage="markdown"
+                    value={prompt}
+                    onChange={(v) => setPrompt(v ?? '')}
+                    theme="vs-dark"
+                    options={{ minimap: { enabled: false }, wordWrap: 'on', fontSize: 14 }}
+                />
+            </Paper>
+
+            <Dialog open={deleteOpen} onClose={() => setDeleteOpen(false)}>
+                <DialogTitle>Delete task "{description || id}"?</DialogTitle>
+                <DialogActions>
+                    <Button onClick={() => setDeleteOpen(false)}>Cancel</Button>
+                    <Button color="error" onClick={handleDelete}>Delete</Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
+    );
+}

--- a/SharpClaw.Web/src/pages/TaskListPage.tsx
+++ b/SharpClaw.Web/src/pages/TaskListPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
+import CardActionArea from '@mui/material/CardActionArea';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import { getTasks } from '../api/tasks';
@@ -16,6 +18,7 @@ function formatDate(iso: string | null): string {
 
 export default function TaskListPage() {
     const [tasks, setTasks] = useState<ScheduledTaskSummary[]>([]);
+    const navigate = useNavigate();
 
     useEffect(() => { getTasks().then(setTasks); }, []);
 
@@ -34,6 +37,7 @@ export default function TaskListPage() {
                 {tasks.map((task) => (
                     <Grid key={task.id} size={{ xs: 12, sm: 6, md: 3 }}>
                         <Card variant="outlined" sx={{ height: '100%', opacity: task.enabled ? 1 : 0.6 }}>
+                            <CardActionArea onClick={() => navigate(`/tasks/${task.id}`)} sx={{ height: '100%' }}>
                             <CardContent>
                                 <Stack direction="row" spacing={1} sx={{ mb: 1, alignItems: 'center' }}>
                                     <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: 1 }} noWrap>
@@ -78,6 +82,7 @@ export default function TaskListPage() {
                                     </Typography>
                                 )}
                             </CardContent>
+                            </CardActionArea>
                         </Card>
                     </Grid>
                 ))}

--- a/SharpClaw/Api/TaskEndpoints.cs
+++ b/SharpClaw/Api/TaskEndpoints.cs
@@ -1,3 +1,5 @@
+using Cronos;
+using SharpClaw.Models;
 using SharpClaw.Scheduling;
 
 namespace SharpClaw.Api;
@@ -23,5 +25,77 @@ internal static class TaskEndpoints
                 LastRun = t.LastRunUtc,
                 Prompt = t.Prompt.Length > 200 ? t.Prompt[..200] + "…" : t.Prompt,
             }));
+
+        group.MapGet("/{id}", (string id, ScheduleStore store) =>
+        {
+            var task = store.Get(id);
+            if (task is null)
+                return Results.NotFound();
+
+            return Results.Ok(new
+            {
+                task.Id,
+                Agent = task.AgentId,
+                task.Description,
+                Cron = task.CronExpression,
+                task.IsOneOff,
+                ChannelKey = task.ChannelKey,
+                ChannelType = task.ChannelType.ToString(),
+                task.Enabled,
+                Created = task.CreatedUtc,
+                NextRun = task.NextRunUtc,
+                LastRun = task.LastRunUtc,
+                task.Prompt,
+            });
+        });
+
+        group.MapPut("/{id}", (string id, TaskUpdateRequest request, ScheduleStore store) =>
+        {
+            var existing = store.Get(id);
+            if (existing is null)
+                return Results.NotFound();
+
+            // Validate cron expression
+            var cronExpr = request.Cron ?? existing.CronExpression;
+            try
+            {
+                CronExpression.Parse(cronExpr, CronFormat.Standard);
+            }
+            catch (CronFormatException)
+            {
+                return Results.BadRequest("Invalid cron expression.");
+            }
+
+            var nextRun = ScheduleStore.ComputeNextRun(cronExpr, DateTimeOffset.UtcNow)
+                          ?? existing.NextRunUtc;
+
+            var updated = existing with
+            {
+                Description = request.Description ?? existing.Description,
+                CronExpression = cronExpr,
+                Prompt = request.Prompt ?? existing.Prompt,
+                Enabled = request.Enabled ?? existing.Enabled,
+                IsOneOff = request.IsOneOff ?? existing.IsOneOff,
+                AgentId = request.Agent ?? existing.AgentId,
+                NextRunUtc = nextRun,
+            };
+
+            store.Save(updated);
+            return Results.Ok(new { updated.Id, Message = "Task updated." });
+        });
+
+        group.MapDelete("/{id}", (string id, ScheduleStore store) =>
+        {
+            return store.Delete(id) ? Results.NoContent() : Results.NotFound();
+        });
     }
+
+    private sealed record TaskUpdateRequest(
+        string? Description,
+        string? Cron,
+        string? Prompt,
+        bool? Enabled,
+        bool? IsOneOff,
+        string? Agent
+    );
 }


### PR DESCRIPTION
Adds the ability to edit scheduled tasks from the web UI.

## Changes

**Backend** ():
- `GET /api/tasks/{id}` — fetch single task with full prompt
- `PUT /api/tasks/{id}` — update task fields (description, cron, prompt, enabled, isOneOff, agent) with cron validation
- `DELETE /api/tasks/{id}` — delete a task

**Frontend**:
- `TaskEditorPage` — form with description, cron expression, agent, enabled/one-off toggles, and Monaco editor for the prompt. Shows metadata (channel, created, next/last run).
- Task cards in the list page are now clickable (navigates to `/tasks/:id`)
- API client extended with `getTask`, `updateTask`, `deleteTask`

Cron expression changes automatically recalculate next run time.