### PR TITLE
Add lazy MCP loading to reduce Anthropic input token usage

### DIFF
--- a/SharpClaw/Execution/AgentRunner.cs
+++ b/SharpClaw/Execution/AgentRunner.cs
@@ -29,20 +29,23 @@ public sealed class AgentRunner(
 
         var adapters = ResolveToolAdapters(request);
         var tools = adapters.Cast<AIFunction>().ToList();
-        var mcpServers = ResolveMcpServers(request);
+        var (eagerMcps, lazyMcps) = ResolveMcpServers(request);
         var systemPrompt = BuildSystemPrompt(request);
 
         logger.LogInformation(
-            "Resolved session configuration: tools={ToolCount}, mcps={McpCount} ({McpNames})",
+            "Resolved session configuration: tools={ToolCount}, mcps={McpCount} ({McpNames}), lazyMcps={LazyCount} ({LazyNames})",
             tools.Count,
-            mcpServers.Count,
-            mcpServers.Count == 0 ? "none" : string.Join(", ", mcpServers.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)));
+            eagerMcps.Count,
+            eagerMcps.Count == 0 ? "none" : string.Join(", ", eagerMcps.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)),
+            lazyMcps.Count,
+            lazyMcps.Count == 0 ? "none" : string.Join(", ", lazyMcps.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)));
 
         var llmRequest = new LlmSessionRequest(
             Model: request.Model,
             SystemPrompt: systemPrompt,
             Tools: tools,
-            McpServers: mcpServers,
+            McpServers: eagerMcps,
+            LazyMcpServers: lazyMcps.Count > 0 ? lazyMcps : null,
             ResumeSessionId: request.ResumeSessionId
         );
 
@@ -106,7 +109,7 @@ public sealed class AgentRunner(
         }).ToList();
     }
 
-    private IReadOnlyDictionary<string, McpServerDefinition> ResolveMcpServers(AgentRunRequest request)
+    private (Dictionary<string, McpServerDefinition> Eager, Dictionary<string, McpServerDefinition> Lazy) ResolveMcpServers(AgentRunRequest request)
     {
         var mcpNames = request.McpServerNames;
         var allServers = mcpRegistry.GetAll();
@@ -138,7 +141,10 @@ public sealed class AgentRunner(
             FormatNames(mcpNames),
             entries.Count == 0 ? "none" : string.Join(", ", entries.Select(x => x.Key).OrderBy(x => x, StringComparer.OrdinalIgnoreCase)));
 
-        return entries.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        var eager = entries.Where(kvp => !kvp.Value.Lazy).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        var lazy = entries.Where(kvp => kvp.Value.Lazy).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+        return (eager, lazy);
     }
 
     private static string FormatNames(IReadOnlyList<string>? names)

--- a/SharpClaw/Execution/AnthropicProvider.cs
+++ b/SharpClaw/Execution/AnthropicProvider.cs
@@ -27,7 +27,7 @@ public sealed class AnthropicProvider(
             .UseFunctionInvocation()
             .Build();
 
-        // Bridge MCP servers to get their tools
+        // Bridge eager MCP servers to get their tools
         McpToolBridge? mcpBridge = null;
         var allTools = new List<AITool>();
 
@@ -43,15 +43,27 @@ public sealed class AnthropicProvider(
             allTools.AddRange(request.Tools);
         }
 
+        // Create activation tools for lazy MCP servers
+        var lazyActivationTools = new List<LazyMcpActivationTool>();
+        if (request.LazyMcpServers is { Count: > 0 })
+        {
+            foreach (var (name, def) in request.LazyMcpServers)
+            {
+                var activationTool = new LazyMcpActivationTool(name, def, loggerFactory, allTools);
+                lazyActivationTools.Add(activationTool);
+                allTools.Add(activationTool);
+            }
+        }
+
         var chatOptions = new ChatOptions
         {
             Tools = allTools.Count > 0 ? allTools : null,
         };
 
-        logger.LogDebug("Created Anthropic session with model {Model}, {ToolCount} tools",
-            model, allTools.Count);
+        logger.LogDebug("Created Anthropic session with model {Model}, {ToolCount} tools ({LazyCount} lazy MCPs pending)",
+            model, allTools.Count, lazyActivationTools.Count);
 
-        return new AnthropicLlmSession(chatClient, chatOptions, request.SystemPrompt, mcpBridge);
+        return new AnthropicLlmSession(chatClient, chatOptions, request.SystemPrompt, mcpBridge, lazyActivationTools);
     }
 
     public async Task<AgentRunResult> SendAsync(ILlmSession session, string prompt, CancellationToken ct = default)
@@ -94,16 +106,19 @@ public sealed class AnthropicProvider(
         public ChatOptions ChatOptions { get; }
         public List<ChatMessage> Messages { get; } = [];
         private readonly McpToolBridge? _mcpBridge;
+        private readonly IReadOnlyList<LazyMcpActivationTool> _lazyActivationTools;
 
         public AnthropicLlmSession(
             IChatClient chatClient,
             ChatOptions chatOptions,
             string? systemPrompt,
-            McpToolBridge? mcpBridge)
+            McpToolBridge? mcpBridge,
+            IReadOnlyList<LazyMcpActivationTool> lazyActivationTools)
         {
             ChatClient = chatClient;
             ChatOptions = chatOptions;
             _mcpBridge = mcpBridge;
+            _lazyActivationTools = lazyActivationTools;
 
             if (!string.IsNullOrEmpty(systemPrompt))
             {
@@ -119,6 +134,9 @@ public sealed class AnthropicProvider(
 
         public async ValueTask DisposeAsync()
         {
+            foreach (var tool in _lazyActivationTools)
+                await tool.DisposeAsync();
+
             if (_mcpBridge is not null)
                 await _mcpBridge.DisposeAsync();
 

--- a/SharpClaw/Execution/CopilotProvider.cs
+++ b/SharpClaw/Execution/CopilotProvider.cs
@@ -47,6 +47,13 @@ public sealed class CopilotProvider(ILogger<CopilotProvider> logger) : ILlmProvi
             ? request.McpServers.ToDictionary(kvp => kvp.Key, kvp => ToSdkConfig(kvp.Value))
             : new Dictionary<string, McpServerConfig>();
 
+        // Copilot SDK manages MCP connections server-side, so lazy MCPs have no token cost — include them eagerly
+        if (request.LazyMcpServers is not null)
+        {
+            foreach (var (name, def) in request.LazyMcpServers)
+                mcpServers[name] = ToSdkConfig(def);
+        }
+
         CopilotSession session;
 
         try

--- a/SharpClaw/Execution/LazyMcpActivationTool.cs
+++ b/SharpClaw/Execution/LazyMcpActivationTool.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using ModelContextProtocol.Client;
+using SharpClaw.Models;
+
+namespace SharpClaw.Execution;
+
+/// <summary>
+/// A lightweight activation tool that defers MCP server connection until first use.
+/// On invocation, connects to the MCP server, discovers its tools, and injects them
+/// into the session's tool list — saving input tokens on every request until needed.
+/// </summary>
+public sealed class LazyMcpActivationTool : AIFunction, IAsyncDisposable
+{
+    private readonly string _serverName;
+    private readonly McpServerDefinition _definition;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly List<AITool> _sessionTools;
+    private readonly ILogger _logger;
+    private McpClient? _client;
+    private bool _activated;
+
+    private static readonly JsonElement EmptySchema = JsonSerializer.SerializeToElement(new
+    {
+        type = "object",
+        properties = new { },
+        required = Array.Empty<string>()
+    });
+
+    public LazyMcpActivationTool(
+        string serverName,
+        McpServerDefinition definition,
+        ILoggerFactory loggerFactory,
+        List<AITool> sessionTools)
+    {
+        _serverName = serverName;
+        _definition = definition;
+        _loggerFactory = loggerFactory;
+        _sessionTools = sessionTools;
+        _logger = loggerFactory.CreateLogger<LazyMcpActivationTool>();
+    }
+
+    public override string Name => $"activate_{_serverName}";
+
+    public override string Description =>
+        $"Activate the {_serverName} toolset. Call this before using any {_serverName} tools. " +
+        $"Once activated, the tools will be available for the rest of the conversation.";
+
+    public override JsonElement JsonSchema => EmptySchema;
+
+    protected override async ValueTask<object?> InvokeCoreAsync(
+        AIFunctionArguments arguments,
+        CancellationToken cancellationToken)
+    {
+        if (_activated)
+            return $"The {_serverName} tools are already activated.";
+
+        try
+        {
+            IClientTransport transport = _definition.Transport.ToLowerInvariant() switch
+            {
+                "http" => new HttpClientTransport(new HttpClientTransportOptions
+                {
+                    Endpoint = new Uri(_definition.Url
+                        ?? throw new InvalidOperationException($"MCP server '{_serverName}' has HTTP transport but no URL")),
+                }, _loggerFactory),
+                "stdio" => new StdioClientTransport(new StdioClientTransportOptions
+                {
+                    Command = _definition.Command
+                        ?? throw new InvalidOperationException($"MCP server '{_serverName}' has stdio transport but no command"),
+                    Arguments = _definition.Args?.ToList(),
+                    EnvironmentVariables = _definition.Env?.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value),
+                }, _loggerFactory),
+                _ => throw new InvalidOperationException($"Unknown MCP transport '{_definition.Transport}' for server '{_serverName}'")
+            };
+
+            _client = await McpClient.CreateAsync(transport, loggerFactory: _loggerFactory, cancellationToken: cancellationToken);
+            var tools = await _client.ListToolsAsync(cancellationToken: cancellationToken);
+
+            // Inject discovered tools into the session's live tool list
+            _sessionTools.AddRange(tools);
+
+            _activated = true;
+
+            var toolNames = tools.Select(t => t.Name).OrderBy(n => n).ToList();
+            _logger.LogInformation(
+                "Lazy MCP '{Server}' activated: {Count} tools discovered ({Tools})",
+                _serverName, toolNames.Count, string.Join(", ", toolNames));
+
+            return $"Activated {_serverName} — {toolNames.Count} tools now available: {string.Join(", ", toolNames)}";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to activate lazy MCP server '{Server}'", _serverName);
+            return $"Error activating {_serverName}: {ex.Message}";
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_client is not null)
+            await _client.DisposeAsync();
+    }
+}

--- a/SharpClaw/Models/LlmSessionRequest.cs
+++ b/SharpClaw/Models/LlmSessionRequest.cs
@@ -7,5 +7,6 @@ public sealed record LlmSessionRequest(
     string? SystemPrompt = null,
     IReadOnlyList<AIFunction>? Tools = null,
     IReadOnlyDictionary<string, McpServerDefinition>? McpServers = null,
+    IReadOnlyDictionary<string, McpServerDefinition>? LazyMcpServers = null,
     string? ResumeSessionId = null
 );

--- a/SharpClaw/Models/McpServerDefinition.cs
+++ b/SharpClaw/Models/McpServerDefinition.cs
@@ -12,4 +12,10 @@ public sealed record McpServerDefinition
     // Http fields
     public string? Url { get; init; }
     public IReadOnlyDictionary<string, string>? Headers { get; init; }
+
+    /// <summary>
+    /// When true, this MCP server is not connected at session start.
+    /// Instead, a lightweight activation tool is provided that connects on first use.
+    /// </summary>
+    public bool Lazy { get; init; }
 }

--- a/SharpClaw/mcps/playwright.json
+++ b/SharpClaw/mcps/playwright.json
@@ -1,5 +1,6 @@
 {
     "transport": "stdio",
     "command": "npx",
-    "args": ["-y", "@playwright/mcp@latest"]
+    "args": ["-y", "@playwright/mcp@latest"],
+    "lazy": true
 }

--- a/SharpClaw/skills/jira-skill/run.sh
+++ b/SharpClaw/skills/jira-skill/run.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATES_DIR="${SCRIPT_DIR}/templates"
+
+# --- Validation ---
+
+check_env() {
+    local missing=()
+    [[ -z "${JIRA_USER_EMAIL:-}" ]] && missing+=("JIRA_USER_EMAIL")
+    [[ -z "${JIRA_API_KEY:-}" ]] && missing+=("JIRA_API_KEY")
+    [[ -z "${JIRA_BASE_URL:-}" ]] && missing+=("JIRA_BASE_URL")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: Missing required environment variables: ${missing[*]}" >&2
+        echo "Set JIRA_USER_EMAIL, JIRA_API_KEY, and JIRA_BASE_URL before running this script." >&2
+        exit 1
+    fi
+}
+
+# --- Helpers ---
+
+jira_api() {
+    local method="$1"
+    local endpoint="$2"
+    local data="${3:-}"
+
+    local url="${JIRA_BASE_URL}/rest/api/3${endpoint}"
+    local auth
+    auth=$(printf '%s:%s' "$JIRA_USER_EMAIL" "$JIRA_API_KEY" | base64 -w0 2>/dev/null || printf '%s:%s' "$JIRA_USER_EMAIL" "$JIRA_API_KEY" | base64)
+
+    local args=(
+        -s -w "\n%{http_code}"
+        -X "$method"
+        -H "Authorization: Basic ${auth}"
+        -H "Content-Type: application/json"
+        -H "Accept: application/json"
+    )
+
+    if [[ -n "$data" ]]; then
+        args+=(-d "$data")
+    fi
+
+    local response
+    response=$(curl "${args[@]}" "$url")
+
+    local http_code
+    http_code=$(echo "$response" | tail -1)
+    local body
+    body=$(echo "$response" | sed '$d')
+
+    if [[ "$http_code" -ge 400 ]]; then
+        echo "ERROR: JIRA API returned HTTP ${http_code}" >&2
+        echo "$body" | jq -r '.errors // .errorMessages // .' 2>/dev/null || echo "$body" >&2
+        exit 1
+    fi
+
+    echo "$body"
+}
+
+load_template() {
+    local project_key="$1"
+    local template_file="${TEMPLATES_DIR}/${project_key}.json"
+
+    if [[ -f "$template_file" ]]; then
+        cat "$template_file"
+    else
+        echo "{}"
+    fi
+}
+
+# --- Commands ---
+
+cmd_create() {
+    local project="" summary="" description="" issue_type="" priority=""
+    local labels="" components="" assignee="" sprint=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --project)  project="$2"; shift 2 ;;
+            --summary)  summary="$2"; shift 2 ;;
+            --description) description="$2"; shift 2 ;;
+            --type)     issue_type="$2"; shift 2 ;;
+            --priority) priority="$2"; shift 2 ;;
+            --labels)   labels="$2"; shift 2 ;;
+            --components) components="$2"; shift 2 ;;
+            --assignee) assignee="$2"; shift 2 ;;
+            --sprint)   sprint="$2"; shift 2 ;;
+            *) echo "ERROR: Unknown flag: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    if [[ -z "$project" ]]; then
+        echo "ERROR: --project is required" >&2; exit 1
+    fi
+    if [[ -z "$summary" ]]; then
+        echo "ERROR: --summary is required" >&2; exit 1
+    fi
+
+    # Load template defaults
+    local template
+    template=$(load_template "$project")
+
+    # Resolve fields (CLI overrides template)
+    issue_type="${issue_type:-$(echo "$template" | jq -r '.issue_type // "Task"')}"
+    priority="${priority:-$(echo "$template" | jq -r '.priority // empty')}"
+    local tpl_labels
+    tpl_labels=$(echo "$template" | jq -r '.labels // [] | join(",")')
+    labels="${labels:-$tpl_labels}"
+    local tpl_components
+    tpl_components=$(echo "$template" | jq -r '.components // [] | join(",")')
+    components="${components:-$tpl_components}"
+
+    # Build JSON payload
+    local payload
+    payload=$(jq -n \
+        --arg project "$project" \
+        --arg summary "$summary" \
+        --arg issuetype "$issue_type" \
+        '{
+            fields: {
+                project: { key: $project },
+                summary: $summary,
+                issuetype: { name: $issuetype }
+            }
+        }')
+
+    # Add description (as ADF)
+    if [[ -n "$description" ]]; then
+        payload=$(echo "$payload" | jq --arg desc "$description" \
+            '.fields.description = {
+                type: "doc",
+                version: 1,
+                content: [{
+                    type: "paragraph",
+                    content: [{
+                        type: "text",
+                        text: $desc
+                    }]
+                }]
+            }')
+    fi
+
+    # Add priority
+    if [[ -n "$priority" ]]; then
+        payload=$(echo "$payload" | jq --arg p "$priority" '.fields.priority = { name: $p }')
+    fi
+
+    # Add labels
+    if [[ -n "$labels" ]]; then
+        payload=$(echo "$payload" | jq --arg l "$labels" '.fields.labels = ($l | split(",") | map(gsub("^\\s+|\\s+$"; "")))')
+    fi
+
+    # Add components
+    if [[ -n "$components" ]]; then
+        payload=$(echo "$payload" | jq --arg c "$components" '.fields.components = ($c | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map({ name: . }))')
+    fi
+
+    # Add assignee
+    if [[ -n "$assignee" ]]; then
+        payload=$(echo "$payload" | jq --arg a "$assignee" '.fields.assignee = { id: $a }')
+    fi
+
+    # Add custom fields from template
+    local custom_fields
+    custom_fields=$(echo "$template" | jq -r '.custom_fields // {}')
+    if [[ "$custom_fields" != "{}" ]]; then
+        payload=$(echo "$payload" | jq --argjson cf "$custom_fields" '.fields += $cf')
+    fi
+
+    # Create the issue
+    local result
+    result=$(jira_api POST "/issue" "$payload")
+
+    local key
+    key=$(echo "$result" | jq -r '.key')
+    local id
+    id=$(echo "$result" | jq -r '.id')
+
+    # Add to sprint if specified
+    if [[ -n "$sprint" ]]; then
+        local sprint_payload
+        sprint_payload=$(jq -n --arg id "$id" '{ issues: [$id] }')
+        jira_api POST "/sprint/${sprint}/issue" "$sprint_payload" >/dev/null 2>&1 || \
+            echo "WARNING: Could not add issue to sprint ${sprint}. You may need to use the Agile API." >&2
+    fi
+
+    echo "✅ Created ticket: **${key}**"
+    echo ""
+    echo "- **Summary:** ${summary}"
+    echo "- **Type:** ${issue_type}"
+    echo "- **Project:** ${project}"
+    [[ -n "$priority" ]] && echo "- **Priority:** ${priority}"
+    [[ -n "$labels" ]] && echo "- **Labels:** ${labels}"
+    echo "- **URL:** ${JIRA_BASE_URL}/browse/${key}"
+}
+
+cmd_fetch() {
+    local project="" sprint="" assignee="" label="" status="" max="50"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --project)  project="$2"; shift 2 ;;
+            --sprint)   sprint="$2"; shift 2 ;;
+            --assignee) assignee="$2"; shift 2 ;;
+            --label)    label="$2"; shift 2 ;;
+            --status)   status="$2"; shift 2 ;;
+            --max)      max="$2"; shift 2 ;;
+            *) echo "ERROR: Unknown flag: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    if [[ -z "$project" ]]; then
+        echo "ERROR: --project is required" >&2; exit 1
+    fi
+
+    # Build JQL query
+    local jql="project = \"${project}\""
+
+    if [[ -n "$sprint" ]]; then
+        jql+=" AND sprint = \"${sprint}\""
+    else
+        jql+=" AND sprint in openSprints()"
+    fi
+
+    if [[ -n "$assignee" ]]; then
+        jql+=" AND assignee = \"${assignee}\""
+    fi
+
+    if [[ -n "$label" ]]; then
+        jql+=" AND labels = \"${label}\""
+    fi
+
+    if [[ -n "$status" ]]; then
+        jql+=" AND status = \"${status}\""
+    fi
+
+    jql+=" ORDER BY priority DESC, created DESC"
+
+    # URL-encode and fetch
+    local encoded_jql
+    encoded_jql=$(printf '%s' "$jql" | jq -sRr @uri)
+
+    local result
+    result=$(jira_api GET "/search?jql=${encoded_jql}&maxResults=${max}&fields=summary,status,assignee,priority,labels")
+
+    local total
+    total=$(echo "$result" | jq -r '.total')
+    local returned
+    returned=$(echo "$result" | jq -r '.issues | length')
+
+    if [[ "$returned" -eq 0 ]]; then
+        echo "No tickets found matching query."
+        echo ""
+        echo "**JQL:** \`${jql}\`"
+        return 0
+    fi
+
+    echo "## Tickets in ${project} (${returned} of ${total})"
+    echo ""
+    echo "| Key | Summary | Status | Assignee | Priority | Labels |"
+    echo "|-----|---------|--------|----------|----------|--------|"
+
+    echo "$result" | jq -r '.issues[] |
+        "| " +
+        .key + " | " +
+        (.fields.summary // "-") + " | " +
+        (.fields.status.name // "-") + " | " +
+        (.fields.assignee.displayName // "Unassigned") + " | " +
+        (.fields.priority.name // "-") + " | " +
+        ((.fields.labels // []) | join(", ")) + " |"'
+
+    echo ""
+    echo "**JQL:** \`${jql}\`"
+}
+
+# --- Main ---
+
+usage() {
+    echo "Usage: $0 <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  create    Create a JIRA ticket"
+    echo "  fetch     Fetch JIRA tickets"
+    echo ""
+    echo "Run '$0 <command> --help' for command-specific options."
+    echo ""
+    echo "Required environment variables:"
+    echo "  JIRA_USER_EMAIL  - Your JIRA email address"
+    echo "  JIRA_API_KEY     - Your JIRA API token"
+    echo "  JIRA_BASE_URL    - Your JIRA instance URL"
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+fi
+
+COMMAND="$1"
+shift
+
+check_env
+
+case "$COMMAND" in
+    create) cmd_create "$@" ;;
+    fetch)  cmd_fetch "$@" ;;
+    -h|--help|help) usage ;;
+    *) echo "ERROR: Unknown command: ${COMMAND}" >&2; usage; exit 1 ;;
+esac

--- a/SharpClaw/skills/jira-skill/skill.md
+++ b/SharpClaw/skills/jira-skill/skill.md
@@ -1,0 +1,130 @@
+# JIRA Integration Skill
+
+You have access to a JIRA integration skill that can create and fetch tickets via the JIRA REST API.
+
+## Required Environment Variables
+
+The following must be set at runtime:
+
+- `JIRA_USER_EMAIL` — The user's JIRA email address (used for Basic Auth)
+- `JIRA_API_KEY` — The JIRA API token (generate at https://id.atlassian.net/manage-profile/security/api-tokens)
+- `JIRA_BASE_URL` — The JIRA instance URL (e.g., `https://mycompany.atlassian.net`)
+
+## Available Commands
+
+### `create` — Create a JIRA ticket
+
+Creates a ticket in a specified project, optionally using a project-specific template for default field values.
+
+**Usage:**
+```bash
+./run.sh create --project <PROJECT_KEY> --summary "<summary>" [options]
+```
+
+**Arguments:**
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--project` | Yes | JIRA project key (e.g., `ENG`, `PLATFORM`) |
+| `--summary` | Yes | Ticket summary/title |
+| `--description` | No | Ticket description (plain text or ADF JSON) |
+| `--type` | No | Issue type override (e.g., `Bug`, `Story`, `Task`) |
+| `--priority` | No | Priority override (e.g., `High`, `Medium`, `Low`) |
+| `--labels` | No | Comma-separated labels (e.g., `backend,urgent`) |
+| `--components` | No | Comma-separated component names |
+| `--assignee` | No | Assignee account ID or email |
+| `--sprint` | No | Sprint ID to add the ticket to |
+
+**Template behaviour:**
+- If a file `templates/<PROJECT_KEY>.json` exists, its fields are used as defaults.
+- Any flags provided on the command line override template values.
+- If no template exists, you must provide at least `--type` (defaults to `Task` otherwise).
+
+**Examples:**
+```bash
+# Create a task using template defaults
+./run.sh create --project ENG --summary "Add rate limiting to API gateway"
+
+# Create a bug with overrides
+./run.sh create --project ENG --summary "Login fails on Safari" --type Bug --priority High --labels "browser,auth"
+
+# Create with full description
+./run.sh create --project PLATFORM --summary "Migrate to PostgreSQL 17" --description "Upgrade from PG 15 to PG 17 for improved JSON performance."
+```
+
+---
+
+### `fetch` — Fetch JIRA tickets
+
+Retrieves tickets from a project/sprint with optional filters.
+
+**Usage:**
+```bash
+./run.sh fetch --project <PROJECT_KEY> [options]
+```
+
+**Arguments:**
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--project` | Yes | JIRA project key |
+| `--sprint` | No | Sprint name or ID (uses active sprint if omitted) |
+| `--assignee` | No | Filter by assignee (account ID or email) |
+| `--label` | No | Filter by label |
+| `--status` | No | Filter by status (e.g., `"In Progress"`, `Done`) |
+| `--max` | No | Maximum results to return (default: 50) |
+
+**Examples:**
+```bash
+# All tickets in the active sprint
+./run.sh fetch --project ENG
+
+# Tickets assigned to a specific user
+./run.sh fetch --project ENG --assignee "john@company.com"
+
+# Tickets with a specific label in a named sprint
+./run.sh fetch --project ENG --sprint "Sprint 42" --label backend
+
+# Filter by status
+./run.sh fetch --project ENG --status "In Progress"
+```
+
+**Output format:**
+Returns a markdown-formatted table with columns: Key, Summary, Status, Assignee, Priority, Labels.
+
+---
+
+## Template Format
+
+Templates live in `skills/jira-skill/templates/<PROJECT_KEY>.json`. Each template defines default field values for ticket creation in that project.
+
+**Structure:**
+```json
+{
+  "project_key": "EXAMPLE",
+  "issue_type": "Story",
+  "priority": "Medium",
+  "labels": ["team-alpha"],
+  "components": ["backend"],
+  "custom_fields": {
+    "customfield_10001": "value"
+  }
+}
+```
+
+**To add a new project template:**
+1. Create a JSON file named `<PROJECT_KEY>.json` in the `templates/` directory.
+2. Define any default fields. Only include fields you want as defaults.
+3. All fields can be overridden at creation time via command-line flags.
+
+## Invocation
+
+The skill script is located at `skills/jira-skill/run.sh`. Invoke it from the SharpClaw root:
+
+```bash
+bash skills/jira-skill/run.sh <command> [flags...]
+```
+
+Or if calling from the skill directory:
+
+```bash
+./run.sh <command> [flags...]
+```

--- a/SharpClaw/skills/jira-skill/templates/EXAMPLE.json
+++ b/SharpClaw/skills/jira-skill/templates/EXAMPLE.json
@@ -1,0 +1,8 @@
+{
+  "project_key": "EXAMPLE",
+  "issue_type": "Story",
+  "priority": "Medium",
+  "labels": ["team-alpha", "backend"],
+  "components": ["api-gateway"],
+  "custom_fields": {}
+}

--- a/SharpClaw/skills/update-appservice-image/README.md
+++ b/SharpClaw/skills/update-appservice-image/README.md
@@ -1,0 +1,61 @@
+# Update App Service Image
+
+Activates the **Website Contributor** role via Azure PIM (Privileged Identity Management), then updates the container image tag on an Azure App Service.
+
+## Prerequisites
+
+- [Azure CLI](https://aka.ms/install-azure-cli) installed and authenticated (`az login`)
+- An eligible PIM assignment for the 'Website Contributor' role on the target resource group
+- `uuidgen` available (standard on Linux/macOS)
+
+## Usage
+
+```bash
+./run.sh -g <resource-group> -n <app-service-name> -i <image:tag> [OPTIONS]
+```
+
+### Required Arguments
+
+| Flag | Description |
+|------|-------------|
+| `-g`, `--resource-group` | Azure resource group name |
+| `-n`, `--name` | App Service name |
+| `-i`, `--image` | Full image reference (e.g. `myregistry.azurecr.io/myapp:v2.1.0`) |
+
+### Optional Arguments
+
+| Flag | Description |
+|------|-------------|
+| `--subscription` | Azure subscription ID (uses current default if omitted) |
+| `--skip-pim` | Skip PIM role activation (use if already elevated) |
+| `--justification` | Justification text for PIM request (default: "Deploying updated container image") |
+| `-h`, `--help` | Show help message |
+
+## Examples
+
+```bash
+# Full flow: activate PIM + update image
+./run.sh -g my-rg -n my-app -i myregistry.azurecr.io/myapp:v2.1.0
+
+# Skip PIM (already elevated)
+./run.sh -g my-rg -n my-app -i myregistry.azurecr.io/myapp:v2.1.0 --skip-pim
+
+# Explicit subscription + custom justification
+./run.sh -g my-rg -n my-app -i myregistry.azurecr.io/myapp:v2.1.0 \
+  --subscription 00000000-0000-0000-0000-000000000000 \
+  --justification "Hotfix for CVE-2026-1234"
+```
+
+## How It Works
+
+1. **PIM Activation** — Calls the Azure PIM REST API (`Microsoft.Authorization/roleAssignmentScheduleRequests`) to self-activate the Website Contributor eligible role assignment. Polls until activation completes (up to 120s timeout).
+
+2. **Image Update** — Uses `az webapp config container set --image` to update the App Service container configuration with the new image reference.
+
+3. **Verification** — Reads back the container config to confirm the image was applied.
+
+## Notes
+
+- PIM activation grants the role for 1 hour by default.
+- The script uses `set -euo pipefail` for strict error handling.
+- All output is timestamped for easy log correlation.

--- a/SharpClaw/skills/update-appservice-image/run.sh
+++ b/SharpClaw/skills/update-appservice-image/run.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update Azure App Service container image with optional PIM role activation.
+
+SCRIPT_NAME="$(basename "$0")"
+RESOURCE_GROUP=""
+APP_NAME=""
+IMAGE=""
+SUBSCRIPTION=""
+SKIP_PIM=false
+JUSTIFICATION="Deploying updated container image"
+PIM_ROLE="Website Contributor"
+PIM_POLL_INTERVAL=5
+PIM_TIMEOUT=120
+
+usage() {
+    cat <<EOF
+Usage: $SCRIPT_NAME [OPTIONS]
+
+Activates the 'Website Contributor' role via Azure PIM, then updates the
+container image tag on an Azure App Service.
+
+Required:
+  -g, --resource-group    Azure resource group name
+  -n, --name              App Service name
+  -i, --image             Full image reference (e.g. myregistry.azurecr.io/myapp:v2.1.0)
+
+Optional:
+  --subscription          Azure subscription ID (uses default if omitted)
+  --skip-pim              Skip PIM role activation (if already elevated)
+  --justification         Justification text for PIM activation (default: "Deploying updated container image")
+  -h, --help              Show this help message
+
+Examples:
+  $SCRIPT_NAME -g my-rg -n my-app -i myregistry.azurecr.io/myapp:v2.1.0
+  $SCRIPT_NAME -g my-rg -n my-app -i myregistry.azurecr.io/myapp:v2.1.0 --skip-pim
+  $SCRIPT_NAME -g my-rg -n my-app -i myregistry.azurecr.io/myapp:v2.1.0 --subscription 00000000-0000-0000-0000-000000000000
+EOF
+}
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+error() { echo "[$(date '+%H:%M:%S')] ERROR: $*" >&2; }
+die() { error "$@"; exit 1; }
+
+# --- Parse arguments ---
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -g|--resource-group) RESOURCE_GROUP="$2"; shift 2 ;;
+        -n|--name)           APP_NAME="$2"; shift 2 ;;
+        -i|--image)          IMAGE="$2"; shift 2 ;;
+        --subscription)      SUBSCRIPTION="$2"; shift 2 ;;
+        --skip-pim)          SKIP_PIM=true; shift ;;
+        --justification)     JUSTIFICATION="$2"; shift 2 ;;
+        -h|--help)           usage; exit 0 ;;
+        *) die "Unknown option: $1. Use --help for usage." ;;
+    esac
+done
+
+# --- Validate required args ---
+
+[[ -z "$RESOURCE_GROUP" ]] && die "Missing required argument: --resource-group"
+[[ -z "$APP_NAME" ]]       && die "Missing required argument: --name"
+[[ -z "$IMAGE" ]]          && die "Missing required argument: --image"
+
+# --- Check prerequisites ---
+
+log "Checking prerequisites..."
+
+if ! command -v az &>/dev/null; then
+    die "Azure CLI (az) is not installed. Install from https://aka.ms/install-azure-cli"
+fi
+
+if ! az account show &>/dev/null; then
+    die "Not logged in to Azure CLI. Run 'az login' first."
+fi
+
+# Resolve subscription
+if [[ -n "$SUBSCRIPTION" ]]; then
+    SUB_FLAG="--subscription $SUBSCRIPTION"
+    SUBSCRIPTION_ID="$SUBSCRIPTION"
+else
+    SUB_FLAG=""
+    SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+fi
+
+log "Using subscription: $SUBSCRIPTION_ID"
+log "Resource group: $RESOURCE_GROUP"
+log "App Service: $APP_NAME"
+log "Image: $IMAGE"
+
+# --- Operation 1: PIM Role Activation ---
+
+activate_pim_role() {
+    log "Activating PIM role '$PIM_ROLE' for resource group '$RESOURCE_GROUP'..."
+
+    # Get current user's object ID
+    local principal_id
+    principal_id=$(az ad signed-in-user show --query id -o tsv) \
+        || die "Failed to get signed-in user object ID"
+
+    # Get the role definition ID for 'Website Contributor'
+    local scope="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}"
+    local role_definition_id
+    role_definition_id=$(az role definition list \
+        --name "$PIM_ROLE" \
+        --scope "$scope" \
+        --query "[0].id" -o tsv) \
+        || die "Failed to find role definition for '$PIM_ROLE'"
+
+    [[ -z "$role_definition_id" ]] && die "Role '$PIM_ROLE' not found at scope $scope"
+
+    # Find the eligible assignment schedule for this principal + role + scope
+    local eligible_assignment_id
+    eligible_assignment_id=$(az rest \
+        --method GET \
+        --url "https://management.azure.com${scope}/providers/Microsoft.Authorization/roleEligibilityScheduleInstances?api-version=2020-10-01&\$filter=principalId eq '${principal_id}' and roleDefinitionId eq '${role_definition_id}'" \
+        --query "value[0].properties.roleEligibilityScheduleId" -o tsv 2>/dev/null) || true
+
+    if [[ -z "$eligible_assignment_id" ]]; then
+        die "No eligible PIM assignment found for role '$PIM_ROLE' on resource group '$RESOURCE_GROUP'. Ensure you have an eligible assignment configured."
+    fi
+
+    # Create a role assignment schedule request (activation)
+    local request_id
+    request_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    local start_time
+    start_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    local body
+    body=$(cat <<ENDJSON
+{
+    "properties": {
+        "principalId": "${principal_id}",
+        "roleDefinitionId": "${role_definition_id}",
+        "requestType": "SelfActivate",
+        "linkedRoleEligibilityScheduleId": "${eligible_assignment_id}",
+        "justification": "${JUSTIFICATION}",
+        "scheduleInfo": {
+            "startDateTime": "${start_time}",
+            "expiration": {
+                "type": "AfterDuration",
+                "duration": "PT1H"
+            }
+        }
+    }
+}
+ENDJSON
+)
+
+    log "Submitting PIM activation request..."
+    local response
+    response=$(az rest \
+        --method PUT \
+        --url "https://management.azure.com${scope}/providers/Microsoft.Authorization/roleAssignmentScheduleRequests/${request_id}?api-version=2020-10-01" \
+        --body "$body" \
+        --headers "Content-Type=application/json" 2>&1) \
+        || die "PIM activation request failed: $response"
+
+    # Poll for activation to complete
+    log "Waiting for PIM activation to complete..."
+    local elapsed=0
+    while [[ $elapsed -lt $PIM_TIMEOUT ]]; do
+        local status
+        status=$(az rest \
+            --method GET \
+            --url "https://management.azure.com${scope}/providers/Microsoft.Authorization/roleAssignmentScheduleRequests/${request_id}?api-version=2020-10-01" \
+            --query "properties.status" -o tsv 2>/dev/null) || true
+
+        case "$status" in
+            Provisioned|Active)
+                log "PIM role activation complete (status: $status)"
+                return 0
+                ;;
+            Failed|Canceled|Denied)
+                die "PIM activation failed with status: $status"
+                ;;
+            *)
+                sleep "$PIM_POLL_INTERVAL"
+                elapsed=$((elapsed + PIM_POLL_INTERVAL))
+                ;;
+        esac
+    done
+
+    die "PIM activation timed out after ${PIM_TIMEOUT}s. Check Azure portal for status."
+}
+
+if [[ "$SKIP_PIM" == "false" ]]; then
+    activate_pim_role
+else
+    log "Skipping PIM activation (--skip-pim specified)"
+fi
+
+# --- Operation 2: Update App Service container image ---
+
+log "Updating App Service container image..."
+
+# shellcheck disable=SC2086
+az webapp config container set \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$APP_NAME" \
+    --image "$IMAGE" \
+    $SUB_FLAG \
+    --output none \
+    || die "Failed to update container image on App Service '$APP_NAME'"
+
+log "Container image updated successfully."
+
+# Verify the update
+log "Verifying configuration..."
+# shellcheck disable=SC2086
+current_image=$(az webapp config container show \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$APP_NAME" \
+    $SUB_FLAG \
+    --query "[?name=='DOCKER_CUSTOM_IMAGE_NAME'].value | [0]" -o tsv 2>/dev/null) || true
+
+if [[ "$current_image" == "$IMAGE" ]]; then
+    log "Verified: App Service is now using image '$IMAGE'"
+else
+    log "Warning: Could not verify image update (got '$current_image'). Check Azure portal."
+fi
+
+log "Done."

--- a/list-anthropic-models.sh
+++ b/list-anthropic-models.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# List available Anthropic model names using the /v1/models API endpoint.
+# Reads API key from appsettings.Development.json or ANTHROPIC_API_KEY env var.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETTINGS_FILE="$SCRIPT_DIR/SharpClaw/appsettings.Development.json"
+
+# Resolve API key
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    API_KEY="$ANTHROPIC_API_KEY"
+elif [[ -f "$SETTINGS_FILE" ]]; then
+    API_KEY=$(python3 -c "import json; print(json.load(open('$SETTINGS_FILE'))['Anthropic']['ApiKey'])")
+else
+    echo "Error: No ANTHROPIC_API_KEY env var and $SETTINGS_FILE not found" >&2
+    exit 1
+fi
+
+if [[ -z "$API_KEY" ]]; then
+    echo "Error: API key is empty" >&2
+    exit 1
+fi
+
+# Fetch models and extract names
+curl -s https://api.anthropic.com/v1/models \
+    -H "x-api-key: $API_KEY" \
+    -H "anthropic-version: 2023-06-01" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+if 'error' in data:
+    print(f\"Error: {data['error']['message']}\", file=sys.stderr)
+    sys.exit(1)
+models = sorted(m['id'] for m in data.get('data', []))
+for m in models:
+    print(m)
+"


### PR DESCRIPTION
## Problem

Every Anthropic API request was burning 10-16k input tokens. The main culprit: tool definitions (~9-10k tokens), especially Playwright's ~25 tools being sent on every request even when the agent doesn't use the browser.

## Solution

MCP servers can now be marked `"lazy": true` in their JSON config. Lazy servers are **not** connected at session start. Instead, a single lightweight activation tool (e.g. `activate_playwright`) is registered (~200 tokens). When the model decides it needs browser tools, it calls the activation tool which:

1. Connects to the MCP server
2. Discovers tools via `ListToolsAsync()`
3. Injects them into the session's live tool list
4. Returns the list of available tools to the model

### Token savings

- Before: ~25 Playwright tool defs × ~200 tokens = **~5,000 tokens per request**
- After: 1 activation tool = **~200 tokens per request** (until activated)

### Copilot provider

For the Copilot SDK provider, lazy MCPs are merged eagerly since tool definitions are managed server-side with no per-request token cost to us.

## Files changed

- `McpServerDefinition`: added `Lazy` property
- `LlmSessionRequest`: added `LazyMcpServers` parameter
- `LazyMcpActivationTool`: new `AIFunction` that connects on demand
- `AnthropicProvider`: creates activation tools for lazy MCPs
- `CopilotProvider`: merges lazy MCPs eagerly (no token cost)
- `AgentRunner`: splits resolved MCPs into eager/lazy partitions
- `mcps/playwright.json`: marked as lazy