### PR TITLE
feat: per-agent lazy MCP loading via lazy_mcps frontmatter

### DIFF
--- a/SharpClaw/Abstractions/IAgent.cs
+++ b/SharpClaw/Abstractions/IAgent.cs
@@ -11,6 +11,7 @@ public interface IAgent
     string? SystemPrompt { get; }
     IReadOnlyList<string> ToolNames { get; }
     IReadOnlyList<string> McpNames { get; }
+    IReadOnlyList<string> LazyMcpNames { get; }
     IReadOnlyList<string> SkillNames { get; }
     IReadOnlyList<string> SubAgentNames { get; }
 }

--- a/SharpClaw/Execution/AgentRunner.cs
+++ b/SharpClaw/Execution/AgentRunner.cs
@@ -141,8 +141,25 @@ public sealed class AgentRunner(
             FormatNames(mcpNames),
             entries.Count == 0 ? "none" : string.Join(", ", entries.Select(x => x.Key).OrderBy(x => x, StringComparer.OrdinalIgnoreCase)));
 
-        var eager = entries.Where(kvp => !kvp.Value.Lazy).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-        var lazy = entries.Where(kvp => kvp.Value.Lazy).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        // Per-agent lazy_mcps override the global Lazy flag on the definition.
+        // If LazyMcpNames is specified, those names are lazy and all others are eager.
+        // If not specified, fall back to the global Lazy flag on each definition.
+        var lazyMcpNames = request.LazyMcpNames;
+
+        var eager = new Dictionary<string, McpServerDefinition>(StringComparer.OrdinalIgnoreCase);
+        var lazy = new Dictionary<string, McpServerDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (name, definition) in entries)
+        {
+            var isLazy = lazyMcpNames is not null
+                ? lazyMcpNames.Contains(name, StringComparer.OrdinalIgnoreCase)
+                : definition.Lazy;
+
+            if (isLazy)
+                lazy[name] = definition;
+            else
+                eager[name] = definition;
+        }
 
         return (eager, lazy);
     }

--- a/SharpClaw/Interactions/AgentInvoker.cs
+++ b/SharpClaw/Interactions/AgentInvoker.cs
@@ -121,7 +121,8 @@ public sealed class AgentInvoker(
                 Model: agent.Model,
                 SystemPromptOverride: systemPrompt,
                 McpServerNames: agent.McpNames.Count > 0 ? agent.McpNames : null,
-                ToolNames: agent.ToolNames.Count > 0 ? agent.ToolNames : null
+                ToolNames: agent.ToolNames.Count > 0 ? agent.ToolNames : null,
+                LazyMcpNames: agent.LazyMcpNames.Count > 0 ? agent.LazyMcpNames : null
             );
             var llmSession = await runner.CreateSessionAsync(request, ct);
             session.SetLlmSession(llmSession);

--- a/SharpClaw/Loading/AgentDefinitionParser.cs
+++ b/SharpClaw/Loading/AgentDefinitionParser.cs
@@ -16,7 +16,7 @@ internal static class AgentDefinitionParser
         var lines = File.ReadAllLines(filePath);
 
         if (lines.Length == 0 || lines[0].Trim() != "---")
-            return new AgentDefinition(name, null, null, null, [], [], [], [], null, BuildPrompt(lines, 0));
+            return new AgentDefinition(name, null, null, null, [], [], [], [], [], null, BuildPrompt(lines, 0));
 
         var endFrontmatter = -1;
         for (var i = 1; i < lines.Length; i++)
@@ -29,7 +29,7 @@ internal static class AgentDefinitionParser
         }
 
         if (endFrontmatter == -1)
-            return new AgentDefinition(name, null, null, null, [], [], [], [], null, BuildPrompt(lines, 0));
+            return new AgentDefinition(name, null, null, null, [], [], [], [], [], null, BuildPrompt(lines, 0));
 
         string? description = null;
         string? llm = null;
@@ -37,6 +37,7 @@ internal static class AgentDefinitionParser
         long? telegramChatId = null;
         var tools = new List<string>();
         var mcpServers = new List<string>();
+        var lazyMcps = new List<string>();
         var skills = new List<string>();
         var subAgents = new List<string>();
         string? currentKey = null;
@@ -52,6 +53,7 @@ internal static class AgentDefinitionParser
                 {
                     case "tools": tools.Add(item); break;
                     case "mcp_servers": mcpServers.Add(item); break;
+                    case "lazy_mcps": lazyMcps.Add(item); break;
                     case "skills": skills.Add(item); break;
                     case "sub_agents": subAgents.Add(item); break;
                 }
@@ -78,6 +80,9 @@ internal static class AgentDefinitionParser
                     case "mcp_servers":
                         ParseInlineList(value, mcpServers);
                         break;
+                    case "lazy_mcps":
+                        ParseInlineList(value, lazyMcps);
+                        break;
                     case "skills":
                         ParseInlineList(value, skills);
                         break;
@@ -89,7 +94,7 @@ internal static class AgentDefinitionParser
         }
 
         var systemPrompt = BuildPrompt(lines, endFrontmatter + 1);
-        return new AgentDefinition(name, description, llm, model, tools, mcpServers, skills, subAgents, telegramChatId, systemPrompt);
+        return new AgentDefinition(name, description, llm, model, tools, mcpServers, lazyMcps, skills, subAgents, telegramChatId, systemPrompt);
     }
 
     private static void ParseInlineList(string value, List<string> target)

--- a/SharpClaw/Models/AgentDefinition.cs
+++ b/SharpClaw/Models/AgentDefinition.cs
@@ -7,6 +7,7 @@ public sealed record AgentDefinition(
     string? Model,
     IReadOnlyList<string> ToolNames,
     IReadOnlyList<string> McpNames,
+    IReadOnlyList<string> LazyMcpNames,
     IReadOnlyList<string> SkillNames,
     IReadOnlyList<string> SubAgentNames,
     long? TelegramChatId,

--- a/SharpClaw/Models/AgentRunRequest.cs
+++ b/SharpClaw/Models/AgentRunRequest.cs
@@ -7,5 +7,6 @@ public sealed record AgentRunRequest(
     string? SystemPromptOverride = null,
     string? ResumeSessionId = null,
     IReadOnlyList<string>? ToolNames = null,
-    IReadOnlyList<string>? McpServerNames = null
+    IReadOnlyList<string>? McpServerNames = null,
+    IReadOnlyList<string>? LazyMcpNames = null
 );

--- a/SharpClaw/agents/cody.agent.md
+++ b/SharpClaw/agents/cody.agent.md
@@ -14,6 +14,8 @@ tools:
 mcp_servers:
   - memory
   - playwright
+lazy_mcps:
+  - playwright
 sub_agents:
   - ade
 skills:


### PR DESCRIPTION
Adds a `lazy_mcps` field to agent frontmatter that overrides the global `lazy` flag on MCP server JSON definitions.

## What

When `lazy_mcps` is specified on an agent, only those listed MCPs are lazy-loaded for that agent — all others load eagerly regardless of their global setting. When omitted, the global `lazy` flag on the MCP definition is used (existing behaviour).

## Example

```yaml
mcp_servers:
  - memory
  - playwright
lazy_mcps:
  - playwright
```

This means Playwright is lazy for this agent but if another agent doesn't list `lazy_mcps`, it falls back to the global flag.

## Changes

- `IAgent` / `AgentDefinition` — added `LazyMcpNames` property
- `AgentRunRequest` — added `LazyMcpNames` parameter
- `AgentDefinitionParser` — parses `lazy_mcps` from frontmatter
- `AgentInvoker` — passes `LazyMcpNames` through to runner
- `AgentRunner.ResolveMcpServers()` — uses per-agent list when present, falls back to global flag
- `cody.agent.md` — uses `lazy_mcps: [playwright]` as example

Build passes with 0 errors.