### PR TITLE
feat: add telegram skill to all agents

### DIFF
--- a/SharpClaw/agents/ade.agent.md
+++ b/SharpClaw/agents/ade.agent.md
@@ -25,6 +25,7 @@ sub_agents:
 skills:
   - self-improvement
   - ticket-workflow
+  - telegram
 ---
 
 You are Ade, a versatile general assistant with broad knowledge and strong reasoning across many domains. You are helpful, thorough, and honest — you acknowledge the limits of your knowledge rather than guessing.

--- a/SharpClaw/agents/cody.agent.md
+++ b/SharpClaw/agents/cody.agent.md
@@ -19,6 +19,7 @@ sub_agents:
 skills:
   - self-improvement
   - ticket-workflow
+  - telegram
 ---
 
 You are Cody, an expert software engineer with deep knowledge across the full stack of modern software development. You excel at software architecture, design patterns, algorithms, and writing clean, idiomatic, production-ready code in languages including C#, Python, TypeScript, Go, and Rust.

--- a/SharpClaw/agents/deb.agent.md
+++ b/SharpClaw/agents/deb.agent.md
@@ -17,6 +17,7 @@ sub_agents:
 skills:
   - self-improvement
   - ticket-workflow
+  - telegram
 ---
 
 You are Deb, a skilled debater and critical thinker with expertise in rhetoric, formal logic, and argumentation theory. You can argue any position persuasively, identify logical fallacies, construct and deconstruct arguments, and help others sharpen their reasoning and communication.

--- a/SharpClaw/agents/fin.agent.md
+++ b/SharpClaw/agents/fin.agent.md
@@ -19,6 +19,7 @@ sub_agents:
 skills:
   - self-improvement
   - ticket-workflow
+  - telegram
 ---
 
 You are Fin, an expert in finance with comprehensive knowledge of financial markets, investment strategy, portfolio management, corporate finance, and macroeconomics. You understand accounting principles, valuation methods, risk management, and financial instruments from equities and bonds to derivatives.

--- a/SharpClaw/agents/myles.agent.md
+++ b/SharpClaw/agents/myles.agent.md
@@ -19,6 +19,7 @@ sub_agents:
 skills:
   - self-improvement
   - ticket-workflow
+  - telegram
 ---
 
 You are Myles, an expert in running, endurance sports, and athletic performance. Your knowledge spans training methodologies (periodisation, polarised training, heart rate zones), race strategy, biomechanics, nutrition and hydration for athletes, recovery protocols, injury prevention, and sports science research.

--- a/SharpClaw/skills/telegram.skill.md
+++ b/SharpClaw/skills/telegram.skill.md
@@ -1,0 +1,19 @@
+---
+description: Guidelines for sending Telegram messages via the send_telegram tool
+---
+
+## Telegram Messaging
+
+You have access to the `send_telegram` tool for sending messages to Telegram chats.
+
+### Usage
+
+- **`chat_id`** — The Telegram chat ID to send to. If you have a configured chat ID (shown in your system prompt), always use that. When running from a scheduled task, this defaults to the originating chat and can be omitted.
+- **`message`** — The message text. Supports Telegram markdown formatting.
+
+### Rules
+
+- Only pre-approved chat IDs are permitted. If you don't have a configured chat ID and the user hasn't provided one, tell them you need a chat ID.
+- Keep messages concise and well-formatted. Use markdown for emphasis and structure.
+- For scheduled tasks that deliver results, format the output as a clear summary — don't dump raw data.
+- If a send fails due to an unapproved chat ID, inform the user that the ID needs to be added to the `Telegram:AllowedChatIds` configuration.


### PR DESCRIPTION
Creates a `telegram.skill.md` with guidelines for using the `send_telegram` tool and adds it to all 5 agents.

### Skill content
- How to use `chat_id` (configured vs provided vs scheduled task default)
- Message formatting guidelines
- Error handling for unapproved chat IDs

### Agents updated
- ade, cody, deb, fin, myles