### PR TITLE
Add command task type to scheduler

### DIFF
--- a/SharpClaw/Models/ScheduledTask.cs
+++ b/SharpClaw/Models/ScheduledTask.cs
@@ -2,6 +2,8 @@ namespace SharpClaw.Models;
 
 public enum ScheduleChannelType { Telegram, Web }
 
+public enum ScheduledTaskType { Agent, Command }
+
 public sealed record ScheduledTask
 {
     public required string Id { get; init; }
@@ -12,6 +14,8 @@ public sealed record ScheduledTask
     public bool IsOneOff { get; init; }
     public required string ChannelKey { get; init; }
     public ScheduleChannelType ChannelType { get; init; }
+    public ScheduledTaskType TaskType { get; init; } = ScheduledTaskType.Agent;
+    public string? Command { get; init; }
     public DateTimeOffset CreatedUtc { get; init; } = DateTimeOffset.UtcNow;
     public DateTimeOffset NextRunUtc { get; set; }
     public DateTimeOffset? LastRunUtc { get; set; }

--- a/SharpClaw/Scheduling/ScheduleStore.cs
+++ b/SharpClaw/Scheduling/ScheduleStore.cs
@@ -117,6 +117,7 @@ public sealed class ScheduleStore
             "---",
             $"id: {task.Id}",
             $"agent: {task.AgentId}",
+            $"type: {task.TaskType.ToString().ToLowerInvariant()}",
             $"cron: \"{task.CronExpression}\"",
             $"one_off: {task.IsOneOff.ToString().ToLowerInvariant()}",
             $"channel_key: \"{task.ChannelKey}\"",
@@ -132,6 +133,9 @@ public sealed class ScheduleStore
 
         if (!string.IsNullOrEmpty(task.Description))
             lines.Add($"description: \"{EscapeYaml(task.Description)}\"");
+
+        if (!string.IsNullOrEmpty(task.Command))
+            lines.Add($"command: \"{EscapeYaml(task.Command)}\"");
 
         lines.Add("---");
         lines.Add(string.Empty);
@@ -168,6 +172,11 @@ public sealed class ScheduleStore
             !props.TryGetValue("cron", out var cron))
             return null;
 
+        var taskType = props.TryGetValue("type", out var typeStr) &&
+                      Enum.TryParse<ScheduledTaskType>(typeStr, true, out var parsedType)
+            ? parsedType
+            : ScheduledTaskType.Agent;
+
         return new ScheduledTask
         {
             Id = id,
@@ -182,6 +191,8 @@ public sealed class ScheduleStore
                           Enum.TryParse<ScheduleChannelType>(ct, true, out var channelType)
                 ? channelType
                 : ScheduleChannelType.Telegram,
+            TaskType = taskType,
+            Command = props.GetValueOrDefault("command"),
             CreatedUtc = props.TryGetValue("created", out var created) &&
                          DateTimeOffset.TryParse(created, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var createdDto)
                 ? createdDto

--- a/SharpClaw/Tools/ScheduleTaskTool.cs
+++ b/SharpClaw/Tools/ScheduleTaskTool.cs
@@ -9,14 +9,15 @@ public sealed class ScheduleTaskTool(
     SchedulingContextAccessor contextAccessor) : ITool
 {
     public string Name => "schedule_task";
-    public string Description => "Schedule a task to run an agent prompt at a specified time. Supports one-off and recurring schedules using cron expressions (5-field standard cron: minute hour day-of-month month day-of-week).";
+    public string Description => "Schedule a task to run an agent prompt or shell command at a specified time. Supports one-off and recurring schedules using cron expressions (5-field standard cron: minute hour day-of-month month day-of-week).";
 
     public IReadOnlyList<ToolParameterDefinition> Parameters { get; } =
     [
-        new("prompt", "string", "The prompt to send to the agent when the task fires.", Required: true),
+        new("prompt", "string", "The prompt to send to the agent when the task fires. Required for agent tasks, used as description for command tasks.", Required: true),
         new("cron_expression", "string", "Standard 5-field cron expression (e.g. '0 8 * * 3' for every Wednesday at 8am UTC).", Required: true),
         new("one_off", "boolean", "If true, the task runs once at the next matching time and is then deleted. Defaults to false (recurring).", Required: false),
         new("description", "string", "A short human-readable description of what this scheduled task does.", Required: false),
+        new("command", "string", "Shell command to execute. When provided, creates a command task instead of an agent task. The command runs in /bin/bash.", Required: false),
     ];
 
     public Task<object?> ExecuteAsync(ToolCallContext context, CancellationToken ct = default)
@@ -25,6 +26,7 @@ public sealed class ScheduleTaskTool(
         var cronExpr = context.GetString("cron_expression");
         var oneOffStr = context.GetString("one_off");
         var description = context.GetString("description");
+        var command = context.GetString("command");
 
         if (string.IsNullOrWhiteSpace(prompt))
             return Task.FromResult<object?>("Error: 'prompt' is required.");
@@ -44,6 +46,7 @@ public sealed class ScheduleTaskTool(
         }
 
         var isOneOff = string.Equals(oneOffStr, "true", StringComparison.OrdinalIgnoreCase);
+        var taskType = string.IsNullOrWhiteSpace(command) ? ScheduledTaskType.Agent : ScheduledTaskType.Command;
 
         // Get channel context
         var schedulingContext = contextAccessor.Current;
@@ -73,6 +76,8 @@ public sealed class ScheduleTaskTool(
             IsOneOff = isOneOff,
             ChannelKey = channelKey,
             ChannelType = channelType,
+            TaskType = taskType,
+            Command = command,
             CreatedUtc = now,
             NextRunUtc = nextRunUtc,
         };
@@ -80,9 +85,12 @@ public sealed class ScheduleTaskTool(
         store.Save(task);
 
         var scheduleType = isOneOff ? "one-off" : "recurring";
-        var result = $"Scheduled {scheduleType} task (ID: {task.Id}). Next run: {nextRunUtc:yyyy-MM-dd HH:mm} UTC. Cron: {cronExpr}";
+        var taskKind = taskType == ScheduledTaskType.Command ? "command" : "agent";
+        var result = $"Scheduled {scheduleType} {taskKind} task (ID: {task.Id}). Next run: {nextRunUtc:yyyy-MM-dd HH:mm} UTC. Cron: {cronExpr}";
         if (!string.IsNullOrEmpty(description))
             result += $"\nDescription: {description}";
+        if (taskType == ScheduledTaskType.Command)
+            result += $"\nCommand: {command}";
 
         return Task.FromResult<object?>(result);
     }

--- a/SharpClaw/Workers/SchedulerWorker.cs
+++ b/SharpClaw/Workers/SchedulerWorker.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using SharpClaw.Abstractions;
 using SharpClaw.Execution;
 using SharpClaw.Models;
@@ -14,6 +15,7 @@ public sealed class SchedulerWorker(
     ILogger<SchedulerWorker> logger) : BackgroundService
 {
     private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromMinutes(5);
 
     private readonly Dictionary<ScheduleChannelType, ITaskResultDelivery> _delivery =
         deliveryHandlers.ToDictionary(d => d.ChannelType);
@@ -68,36 +70,11 @@ public sealed class SchedulerWorker(
 
     private async Task ExecuteTaskAsync(ScheduledTask task, CancellationToken ct)
     {
-        var agent = agentRegistry.Get(task.AgentId);
-        if (agent is null)
+        var responseText = task.TaskType switch
         {
-            logger.LogWarning("Agent '{Agent}' not found for scheduled task {TaskId} — disabling task",
-                task.AgentId, task.Id);
-            task.Enabled = false;
-            store.Save(task);
-            return;
-        }
-
-        logger.LogInformation("Executing scheduled task {TaskId}: agent={Agent}, prompt={Prompt}",
-            task.Id, task.AgentId, task.Prompt[..Math.Min(task.Prompt.Length, 80)]);
-
-        // Set scheduling context so tools (e.g. send_telegram) can access channel info
-        schedulingContextAccessor.Current = new SchedulingContext(
-            task.ChannelKey, task.ChannelType, task.AgentId);
-
-        var request = new AgentRunRequest(
-            Prompt: task.Prompt,
-            Llm: agent.Llm,
-            Model: agent.Model,
-            SystemPromptOverride: agent.SystemPrompt,
-            McpServerNames: agent.McpNames.Count > 0 ? agent.McpNames : null,
-            ToolNames: agent.ToolNames.Count > 0 ? agent.ToolNames : null
-        );
-
-        var result = await runner.RunAsync(request, ct);
-        var responseText = result.Success
-            ? result.Response ?? "(no response)"
-            : $"[Task error: {result.Error}]";
+            ScheduledTaskType.Command => await ExecuteCommandTaskAsync(task, ct),
+            _ => await ExecuteAgentTaskAsync(task, ct)
+        };
 
         // Deliver result
         if (_delivery.TryGetValue(task.ChannelType, out var delivery))
@@ -134,5 +111,119 @@ public sealed class SchedulerWorker(
                 logger.LogWarning("Task {TaskId} has no future occurrences — disabled", task.Id);
             }
         }
+    }
+
+    private async Task<string> ExecuteAgentTaskAsync(ScheduledTask task, CancellationToken ct)
+    {
+        var agent = agentRegistry.Get(task.AgentId);
+        if (agent is null)
+        {
+            logger.LogWarning("Agent '{Agent}' not found for scheduled task {TaskId} — disabling task",
+                task.AgentId, task.Id);
+            task.Enabled = false;
+            store.Save(task);
+            return $"[Task error: Agent '{task.AgentId}' not found — task disabled]";
+        }
+
+        logger.LogInformation("Executing agent task {TaskId}: agent={Agent}, prompt={Prompt}",
+            task.Id, task.AgentId, task.Prompt[..Math.Min(task.Prompt.Length, 80)]);
+
+        // Set scheduling context so tools (e.g. send_telegram) can access channel info
+        schedulingContextAccessor.Current = new SchedulingContext(
+            task.ChannelKey, task.ChannelType, task.AgentId);
+
+        var request = new AgentRunRequest(
+            Prompt: task.Prompt,
+            Llm: agent.Llm,
+            Model: agent.Model,
+            SystemPromptOverride: agent.SystemPrompt,
+            McpServerNames: agent.McpNames.Count > 0 ? agent.McpNames : null,
+            ToolNames: agent.ToolNames.Count > 0 ? agent.ToolNames : null,
+            LazyMcpNames: agent.LazyMcpNames.Count > 0 ? agent.LazyMcpNames : null
+        );
+
+        var result = await runner.RunAsync(request, ct);
+        return result.Success
+            ? result.Response ?? "(no response)"
+            : $"[Task error: {result.Error}]";
+    }
+
+    private async Task<string> ExecuteCommandTaskAsync(ScheduledTask task, CancellationToken ct)
+    {
+        var command = task.Command;
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            logger.LogWarning("Command task {TaskId} has no command — disabling", task.Id);
+            task.Enabled = false;
+            store.Save(task);
+            return "❌ Command task has no command configured — task disabled.";
+        }
+
+        logger.LogInformation("Executing command task {TaskId}: command={Command}",
+            task.Id, command[..Math.Min(command.Length, 80)]);
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(CommandTimeout);
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                Arguments = $"-c \"{command.Replace("\"", "\\\"")}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using var process = new Process { StartInfo = psi };
+            process.Start();
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cts.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(cts.Token);
+
+            await process.WaitForExitAsync(cts.Token);
+            sw.Stop();
+
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+            var exitCode = process.ExitCode;
+
+            logger.LogInformation("Command task {TaskId} completed: exit={ExitCode}, elapsed={Elapsed}ms",
+                task.Id, exitCode, sw.ElapsedMilliseconds);
+
+            if (exitCode == 0)
+            {
+                var output = string.IsNullOrWhiteSpace(stdout) ? "(no output)" : Truncate(stdout, 500);
+                return $"✅ Command completed successfully ({sw.Elapsed.TotalSeconds:F1}s)\n```\n{output}\n```";
+            }
+            else
+            {
+                var errorOutput = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+                errorOutput = string.IsNullOrWhiteSpace(errorOutput) ? "(no output)" : Truncate(errorOutput, 500);
+                return $"❌ Command failed (exit code {exitCode}, {sw.Elapsed.TotalSeconds:F1}s)\n```\n{errorOutput}\n```";
+            }
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            sw.Stop();
+            logger.LogWarning("Command task {TaskId} timed out after {Timeout}s", task.Id, CommandTimeout.TotalSeconds);
+            return $"❌ Command timed out after {CommandTimeout.TotalSeconds}s";
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            logger.LogError(ex, "Command task {TaskId} threw an exception", task.Id);
+            return $"❌ Command error: {ex.Message}";
+        }
+    }
+
+    private static string Truncate(string text, int maxLength)
+    {
+        text = text.Trim();
+        return text.Length <= maxLength ? text : text[..maxLength] + "\n… (truncated)";
     }
 }

--- a/docs/docs/features/scheduling.md
+++ b/docs/docs/features/scheduling.md
@@ -4,15 +4,34 @@ sidebar_position: 8
 
 # Scheduling
 
-The scheduling system allows agents to create one-off or recurring tasks that execute automatically at specified times. Results are delivered back to the originating channel (Telegram or web).
+The scheduling system allows agents to create one-off or recurring tasks that execute automatically at specified times. Tasks can either invoke an agent with a prompt, or run a shell command directly. Results are delivered back to the originating channel (Telegram or web).
 
 ## How It Works
 
 1. A user asks an agent something like _"Find me the top 5 news stories every Wednesday at 8am"_
-2. The agent calls the `schedule_task` tool with a cron expression and prompt
+2. The agent calls the `schedule_task` tool with a cron expression and prompt (or command)
 3. SharpClaw persists the task as a `.task.md` file in the workspace
 4. The `SchedulerWorker` background service checks for due tasks every 30 seconds
-5. When a task is due, the agent runs the prompt and delivers the result to the original channel
+5. When a task is due:
+   - **Agent tasks**: The agent runs the prompt and delivers the result
+   - **Command tasks**: The shell command executes and success/failure is delivered
+6. Results are delivered to the original channel (Telegram or web)
+
+## Task Types
+
+### Agent Tasks (default)
+
+The traditional behaviour — runs a prompt through an agent and delivers the response.
+
+### Command Tasks
+
+Runs a shell command directly via `/bin/bash` without invoking an agent. Ideal for:
+
+- Data collection (API calls, downloads)
+- File maintenance (cleanup, rotation)
+- Pre-fetching data that agents will summarise later
+
+Command tasks report ✅ success or ❌ failure (with output/error) back to the channel. They have a 5-minute timeout.
 
 ## Tools
 
@@ -26,6 +45,7 @@ Creates a new scheduled task.
 | `cron_expression` | string  | Yes      | Standard 5-field cron expression (minute hour day-of-month month day-of-week) |
 | `one_off`         | boolean | No       | If true, runs once then auto-deletes. Defaults to false (recurring)           |
 | `description`     | string  | No       | Human-readable summary of the scheduled task                                  |
+| `command`         | string  | No       | Shell command to execute. When provided, creates a command task instead of an agent task |
 
 **Cron examples:**
 
@@ -35,6 +55,17 @@ Creates a new scheduled task.
 | `0 7 * * 1-5` | Weekdays at 7:00 AM           |
 | `30 9 1 * *`  | 1st of every month at 9:30 AM |
 | `0 */4 * * *` | Every 4 hours                 |
+
+**Command task example:**
+
+```
+schedule_task(
+  prompt: "Fetch daily Anthropic usage data",
+  cron_expression: "0 6 * * *",
+  command: "curl -sH 'Authorization: Bearer $ANTHROPIC_ADMIN_KEY' https://api.anthropic.com/v1/... | jq -r ... >> /data/usage.csv",
+  description: "Daily Anthropic API usage fetch"
+)
+```
 
 ### `cancel_task`
 
@@ -59,6 +90,7 @@ Tasks are stored as individual `.task.md` files in `{workspace}/schedules/`. Eac
 ---
 id: a1b2c3d4
 agent: myles
+type: agent
 cron: "0 8 * * 3"
 one_off: false
 channel_key: "123456789"
@@ -70,6 +102,27 @@ description: "Top 5 news stories weekly"
 ---
 
 Find me the top 5 news stories this week and summarise them.
+```
+
+A command task looks like:
+
+```markdown
+---
+id: b2c3d4e5
+agent: cody
+type: command
+cron: "0 6 * * *"
+one_off: false
+channel_key: "123456789"
+channel_type: Telegram
+created: 2026-06-01T10:00:00+00:00
+next_run: 2026-06-02T06:00:00+00:00
+enabled: true
+description: "Daily Anthropic usage fetch"
+command: "curl -s ... >> /data/usage.csv"
+---
+
+Fetch daily Anthropic usage data
 ```
 
 Tasks survive service restarts — the `SchedulerWorker` reloads them from disk on startup.
@@ -86,11 +139,17 @@ Tasks survive service restarts — the `SchedulerWorker` reloads them from disk 
                                               │SchedulerWorker│ (30s tick)
                                               └───────┬───────┘
                                                       │
-                                              ┌───────▼───────┐
-                                              │  AgentRunner   │ (one-shot)
-                                              └───────┬───────┘
-                                                      │
-                                              ┌───────▼───────┐
+                                        ┌─────────────┼─────────────┐
+                                        │ type=agent  │ type=command │
+                                        ▼             │             ▼
+                                ┌──────────────┐     │     ┌──────────────┐
+                                │ AgentRunner  │     │     │  /bin/bash   │
+                                │ (one-shot)   │     │     │  (process)   │
+                                └──────┬───────┘     │     └──────┬───────┘
+                                       │             │            │
+                                       └─────────────┼────────────┘
+                                                     ▼
+                                              ┌───────────────┐
                                               │ Delivery       │
                                               │ (Telegram/Web) │
                                               └───────────────┘


### PR DESCRIPTION
Adds a `command` task type to the scheduling system. Scheduled tasks can now run shell commands directly without invoking an LLM agent.

## What changed

- **`ScheduledTask` model**: New `TaskType` enum (`Agent`/`Command`) and `Command` property
- **`SchedulerWorker`**: Splits execution into agent vs command paths. Command tasks run via `/bin/bash` with a 5-minute timeout
- **`ScheduleTaskTool`**: New optional `command` parameter — when provided, creates a command task
- **`ScheduleStore`**: Serializes/parses the new `type` and `command` frontmatter fields
- **Docs**: Updated scheduling docs with command task documentation and examples

## Use case

Data collection tasks (e.g. curl → CSV) that don't need LLM reasoning but whose results should still be reported to the agent's channel. An agent task can then summarise the collected data later — separating cheap data fetching from expensive LLM analysis.

## Delivery

Command tasks deliver ✅/❌ status messages (with truncated output) to the originating Telegram/web channel, same as agent tasks.

## Backward compatible

Existing tasks default to `type: agent` — no changes needed for current scheduled tasks.