### PR TITLE
Run git pull before starting web UI dev server

### DIFF
--- a/sharpclaw.sh
+++ b/sharpclaw.sh
@@ -154,6 +154,10 @@ start_docs() {
 }
 
 start_web() {
+  # Pull latest changes
+  echo "Pulling latest changes..."
+  (cd "${ROOT_DIR}" && git pull --quiet) || true
+
   # Kill existing web dev server if running
   if [[ -f "${WEB_PID_FILE}" ]]; then
     local old_pid


### PR DESCRIPTION
Adds a `git pull` in `start_web()` so the web UI always picks up the latest code before launching the Vite dev server. Failure is non-fatal (won't block startup).