### PR TITLE
Add CORS policy to fix 405 on cross-origin requests

### DIFF
--- a/SharpClaw/Program.cs
+++ b/SharpClaw/Program.cs
@@ -24,6 +24,17 @@ using SharpClaw.Workspace;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// -- CORS (allow Web UI access from any origin) --
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+
 // -- Configuration binding --
 builder.Services.Configure<SharpClawOptions>(builder.Configuration.GetSection(SharpClawOptions.SectionName));
 builder.Services.Configure<TelegramOptions>(builder.Configuration.GetSection(TelegramOptions.SectionName));
@@ -192,6 +203,7 @@ if (!string.IsNullOrEmpty(telegramToken) && telegramToken != "YOUR_BOT_TOKEN_HER
 }
 
 // -- Static files (Web UI) --
+app.UseCors();
 app.UseWebSockets(new WebSocketOptions
 {
     KeepAliveInterval = TimeSpan.FromSeconds(30),


### PR DESCRIPTION
## Problem

Accessing the Web UI via IP address (e.g. `http://100.103.191.81:5100`) causes the browser to treat API requests as cross-origin. The browser sends an OPTIONS preflight before POST/PUT/DELETE requests, and without CORS middleware, ASP.NET returns 405 Method Not Allowed.

## Fix

Added a permissive CORS policy (`AllowAnyOrigin`, `AllowAnyMethod`, `AllowAnyHeader`) since SharpClaw is an internal tool. `UseCors()` is placed before WebSocket and static file middleware.

## Testing

- `dotnet build` passes
- Verified direct POST to `/api/tasks` still returns 201
- Requires restart to take effect