### PR TITLE
feat: Semantic Memory Phase 1 — Foundation

### DIFF
--- a/SharpClaw/Configuration/SemanticMemoryOptions.cs
+++ b/SharpClaw/Configuration/SemanticMemoryOptions.cs
@@ -1,0 +1,15 @@
+namespace SharpClaw.Configuration;
+
+public sealed class SemanticMemoryOptions
+{
+    public const string SectionName = "SemanticMemory";
+
+    public bool Enabled { get; set; }
+    public string ModelPath { get; set; } = "models/all-MiniLM-L6-v2.onnx";
+    public string TokenizerPath { get; set; } = "models/tokenizer.json";
+    public string DatabasePath { get; set; } = "data/semantic-memory.db";
+    public int TopK { get; set; } = 5;
+    public float MinScore { get; set; } = 0.3f;
+    public int EmbeddingDimension { get; set; } = 384;
+    public int MaxContextTokens { get; set; } = 1500;
+}

--- a/SharpClaw/Interactions/AgentInvoker.cs
+++ b/SharpClaw/Interactions/AgentInvoker.cs
@@ -2,6 +2,7 @@ using SharpClaw.Abstractions;
 using SharpClaw.Auditing;
 using SharpClaw.Commands;
 using SharpClaw.Execution;
+using SharpClaw.Memory;
 using SharpClaw.Models;
 using SharpClaw.Scheduling;
 using SharpClaw.Sessions;
@@ -16,6 +17,7 @@ public sealed class AgentInvoker(
     AuditService auditService,
     TranscriptService transcriptService,
     SchedulingContextAccessor schedulingContextAccessor,
+    SemanticMemoryService? semanticMemory,
     ILogger<AgentInvoker> logger)
 {
     public async Task<(string? SwitchedTo, string? ResponseText)> InvokeAsync(
@@ -142,7 +144,7 @@ public sealed class AgentInvoker(
                 session.SessionId);
         }
 
-        var result = await runner.SendAsync(session.LlmSession!, prompt, agent.Llm, ct);
+        var result = await runner.SendAsync(session.LlmSession!, await EnrichWithMemoryAsync(prompt, session.AgentId, ct), agent.Llm, ct);
 
         var responseText = result.Success
             ? result.Response
@@ -212,5 +214,25 @@ public sealed class AgentInvoker(
             return string.IsNullOrEmpty(basePrompt) ? null : basePrompt;
 
         return $"{basePrompt}\n\n---\n\n{string.Join("\n\n", skillPrompts)}";
+    }
+
+    private async Task<string> EnrichWithMemoryAsync(string prompt, string agentName, CancellationToken ct)
+    {
+        if (semanticMemory is null) return prompt;
+
+        try
+        {
+            var memories = await semanticMemory.RecallAsync(prompt, agentName, ct: ct);
+            if (memories.Count == 0) return prompt;
+
+            var context = semanticMemory.FormatRecalledContext(memories);
+            logger.LogDebug("Injecting {Count} recalled memories for agent {Agent}", memories.Count, agentName);
+            return $"{context}\n\n{prompt}";
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to recall semantic memories for agent {Agent}", agentName);
+            return prompt;
+        }
     }
 }

--- a/SharpClaw/Memory/EmbeddingService.cs
+++ b/SharpClaw/Memory/EmbeddingService.cs
@@ -1,0 +1,133 @@
+using System.Numerics.Tensors;
+using Microsoft.Extensions.Options;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Memory;
+
+public sealed class EmbeddingService : IDisposable
+{
+    private readonly InferenceSession _session;
+    private readonly int _dimension;
+    private readonly ILogger<EmbeddingService> _logger;
+    private bool _disposed;
+
+    public EmbeddingService(IOptions<SemanticMemoryOptions> options, ILogger<EmbeddingService> logger)
+    {
+        _logger = logger;
+        _dimension = options.Value.EmbeddingDimension;
+
+        var modelPath = Path.IsPathRooted(options.Value.ModelPath)
+            ? options.Value.ModelPath
+            : Path.Combine(AppContext.BaseDirectory, options.Value.ModelPath);
+
+        if (!File.Exists(modelPath))
+            throw new FileNotFoundException($"ONNX embedding model not found at '{modelPath}'");
+
+        var sessionOptions = new Microsoft.ML.OnnxRuntime.SessionOptions
+        {
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+        };
+        sessionOptions.AppendExecutionProvider_CPU();
+
+        _session = new InferenceSession(modelPath, sessionOptions);
+        _logger.LogInformation("Loaded embedding model from {Path} (dimension={Dim})", modelPath, _dimension);
+    }
+
+    public int Dimension => _dimension;
+
+    public float[] GenerateEmbedding(string text)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (string.IsNullOrWhiteSpace(text))
+            return new float[_dimension];
+
+        // Simple whitespace tokenization with [CLS]/[SEP] — for MiniLM we use token IDs
+        // In production, use a proper tokenizer. For now, we encode using simple word-piece approximation.
+        var tokens = SimpleTokenize(text);
+
+        var inputIds = new DenseTensor<long>(new[] { 1, tokens.Length });
+        var attentionMask = new DenseTensor<long>(new[] { 1, tokens.Length });
+        var tokenTypeIds = new DenseTensor<long>(new[] { 1, tokens.Length });
+
+        for (var i = 0; i < tokens.Length; i++)
+        {
+            inputIds[0, i] = tokens[i];
+            attentionMask[0, i] = 1;
+            tokenTypeIds[0, i] = 0;
+        }
+
+        var inputs = new List<NamedOnnxValue>
+        {
+            NamedOnnxValue.CreateFromTensor("input_ids", inputIds),
+            NamedOnnxValue.CreateFromTensor("attention_mask", attentionMask),
+            NamedOnnxValue.CreateFromTensor("token_type_ids", tokenTypeIds)
+        };
+
+        using var results = _session.Run(inputs);
+
+        // MiniLM outputs last_hidden_state [1, seq_len, 384] — mean pool over sequence
+        var output = results.First().AsTensor<float>();
+        var embedding = MeanPool(output, tokens.Length);
+
+        // L2 normalize
+        var norm = MathF.Sqrt(TensorPrimitives.Dot(embedding, embedding));
+        if (norm > 0)
+        {
+            for (var i = 0; i < embedding.Length; i++)
+                embedding[i] /= norm;
+        }
+
+        return embedding;
+    }
+
+    private float[] MeanPool(Microsoft.ML.OnnxRuntime.Tensors.Tensor<float> hiddenState, int seqLen)
+    {
+        var embedding = new float[_dimension];
+        for (var i = 0; i < seqLen; i++)
+        {
+            for (var j = 0; j < _dimension; j++)
+            {
+                embedding[j] += hiddenState[0, i, j];
+            }
+        }
+
+        for (var j = 0; j < _dimension; j++)
+            embedding[j] /= seqLen;
+
+        return embedding;
+    }
+
+    /// <summary>
+    /// Simple tokenization: [CLS] + char-level token IDs + [SEP], capped at 512 tokens.
+    /// This is a placeholder — proper WordPiece tokenization should be added for better quality.
+    /// </summary>
+    private static long[] SimpleTokenize(string text, int maxLength = 512)
+    {
+        // For BERT-family models, we approximate with character-based encoding
+        // [CLS]=101, [SEP]=102, [UNK]=100
+        var chars = text.ToLowerInvariant().ToCharArray();
+        var tokenCount = Math.Min(chars.Length, maxLength - 2);
+        var tokens = new long[tokenCount + 2];
+
+        tokens[0] = 101; // [CLS]
+        for (var i = 0; i < tokenCount; i++)
+        {
+            var c = chars[i];
+            // Map ASCII printable to token range; non-ASCII to [UNK]
+            tokens[i + 1] = c is >= ' ' and <= '~' ? c + 900 : 100;
+        }
+        tokens[tokenCount + 1] = 102; // [SEP]
+
+        return tokens;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _session.Dispose();
+    }
+}

--- a/SharpClaw/Memory/SemanticMemoryEntry.cs
+++ b/SharpClaw/Memory/SemanticMemoryEntry.cs
@@ -1,0 +1,29 @@
+namespace SharpClaw.Memory;
+
+public enum MemoryType
+{
+    Fact,
+    Decision,
+    Preference,
+    Learning
+}
+
+public sealed record SemanticMemoryEntry
+{
+    public required string Id { get; init; }
+    public required string Content { get; init; }
+    public required string AgentName { get; init; }
+    public MemoryType Type { get; init; } = MemoryType.Fact;
+    public float TrustScore { get; init; } = 1.0f;
+    public int AccessCount { get; init; }
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset LastAccessedAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record RecalledMemory(
+    string Id,
+    string Content,
+    MemoryType Type,
+    float Score,
+    float TrustScore);

--- a/SharpClaw/Memory/SemanticMemoryService.cs
+++ b/SharpClaw/Memory/SemanticMemoryService.cs
@@ -1,0 +1,98 @@
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Memory;
+
+public sealed class SemanticMemoryService(
+    SemanticMemoryStore store,
+    EmbeddingService embeddingService,
+    IOptions<SemanticMemoryOptions> options,
+    ILogger<SemanticMemoryService> logger)
+{
+    private readonly SemanticMemoryOptions _options = options.Value;
+
+    public async Task StoreAsync(
+        string content,
+        string agentName,
+        MemoryType type = MemoryType.Fact,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(content)) return;
+
+        var embedding = embeddingService.GenerateEmbedding(content);
+
+        // Dedup: skip if very similar memory already exists
+        if (await store.HasSimilarAsync(embedding, agentName, 0.92f, ct))
+        {
+            logger.LogDebug("Skipping duplicate memory for agent {Agent}: {Content}", agentName, content[..Math.Min(50, content.Length)]);
+            return;
+        }
+
+        var entry = new SemanticMemoryEntry
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Content = content,
+            AgentName = agentName,
+            Type = type,
+            TrustScore = 1.0f,
+            CreatedAt = DateTimeOffset.UtcNow,
+            LastAccessedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        await store.StoreAsync(entry, embedding, ct);
+        logger.LogDebug("Stored semantic memory {Id} ({Type}) for agent {Agent}", entry.Id, type, agentName);
+    }
+
+    public async Task<IReadOnlyList<RecalledMemory>> RecallAsync(
+        string query,
+        string agentName,
+        int? topK = null,
+        float? minScore = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return [];
+
+        var k = topK ?? _options.TopK;
+        var score = minScore ?? _options.MinScore;
+
+        var embedding = embeddingService.GenerateEmbedding(query);
+        var vectorResults = await store.RecallByVectorAsync(embedding, agentName, k, score, ct);
+
+        // Update access counts for recalled memories
+        foreach (var memory in vectorResults)
+        {
+            await store.UpdateAccessAsync(memory.Id, ct);
+        }
+
+        if (vectorResults.Count > 0)
+        {
+            logger.LogDebug(
+                "Recalled {Count} memories for agent {Agent} (top score: {Score:F3})",
+                vectorResults.Count, agentName, vectorResults[0].Score);
+        }
+
+        return vectorResults;
+    }
+
+    public string FormatRecalledContext(IReadOnlyList<RecalledMemory> memories)
+    {
+        if (memories.Count == 0) return string.Empty;
+
+        var lines = memories.Select(m =>
+            $"- [{m.Type}] {m.Content} (relevance: {m.Score:F2})");
+
+        return $"[Relevant context from memory]\n{string.Join("\n", lines)}\n[End memory context]";
+    }
+
+    public async Task DecayAsync(CancellationToken ct = default)
+    {
+        await store.DecayAllAsync(0.95f, ct);
+    }
+
+    public async Task<int> GetMemoryCountAsync(string? agentName = null, CancellationToken ct = default)
+    {
+        return await store.GetCountAsync(agentName, ct);
+    }
+}

--- a/SharpClaw/Memory/SemanticMemoryStore.cs
+++ b/SharpClaw/Memory/SemanticMemoryStore.cs
@@ -1,0 +1,371 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Memory;
+
+public sealed class SemanticMemoryStore : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly int _dimension;
+    private readonly ILogger<SemanticMemoryStore> _logger;
+    private bool _disposed;
+
+    public SemanticMemoryStore(IOptions<SemanticMemoryOptions> options, ILogger<SemanticMemoryStore> logger)
+    {
+        _logger = logger;
+        _dimension = options.Value.EmbeddingDimension;
+
+        var dbPath = Path.IsPathRooted(options.Value.DatabasePath)
+            ? options.Value.DatabasePath
+            : Path.Combine(AppContext.BaseDirectory, options.Value.DatabasePath);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+
+        _connection = new SqliteConnection($"Data Source={dbPath}");
+        _connection.Open();
+
+        InitializeSchema();
+        _logger.LogInformation("Semantic memory store initialized at {Path}", dbPath);
+    }
+
+    private void InitializeSchema()
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS memories (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                type INTEGER NOT NULL DEFAULT 0,
+                trust_score REAL NOT NULL DEFAULT 1.0,
+                access_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                last_accessed_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                embedding BLOB NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_memories_agent ON memories(agent_name);
+            CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(type);
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+                content,
+                content_rowid='rowid'
+            );
+            """;
+        cmd.ExecuteNonQuery();
+
+        // Attempt to load sqlite-vec extension and create vec table
+        TryInitializeVecTable();
+    }
+
+    private void TryInitializeVecTable()
+    {
+        try
+        {
+            using var vecCmd = _connection.CreateCommand();
+            vecCmd.CommandText = $"""
+                CREATE VIRTUAL TABLE IF NOT EXISTS memories_vec USING vec0(
+                    id TEXT PRIMARY KEY,
+                    embedding float[{_dimension}]
+                );
+                """;
+            vecCmd.ExecuteNonQuery();
+            _logger.LogInformation("sqlite-vec extension available; using vector index for similarity search");
+        }
+        catch (SqliteException ex)
+        {
+            _logger.LogInformation(
+                "sqlite-vec extension not available; using brute-force similarity search. Detail: {Message}",
+                ex.Message);
+        }
+    }
+
+    public async Task StoreAsync(SemanticMemoryEntry entry, float[] embedding, CancellationToken ct = default)
+    {
+        await Task.CompletedTask; // Sync SQLite ops wrapped for async interface
+
+        using var transaction = _connection.BeginTransaction();
+
+        try
+        {
+            // Insert into main table
+            using var cmd = _connection.CreateCommand();
+            cmd.Transaction = transaction;
+            cmd.CommandText = """
+                INSERT OR REPLACE INTO memories (id, content, agent_name, type, trust_score, access_count, created_at, last_accessed_at, updated_at, embedding)
+                VALUES (@id, @content, @agent_name, @type, @trust_score, @access_count, @created_at, @last_accessed_at, @updated_at, @embedding)
+                """;
+            cmd.Parameters.AddWithValue("@id", entry.Id);
+            cmd.Parameters.AddWithValue("@content", entry.Content);
+            cmd.Parameters.AddWithValue("@agent_name", entry.AgentName);
+            cmd.Parameters.AddWithValue("@type", (int)entry.Type);
+            cmd.Parameters.AddWithValue("@trust_score", entry.TrustScore);
+            cmd.Parameters.AddWithValue("@access_count", entry.AccessCount);
+            cmd.Parameters.AddWithValue("@created_at", entry.CreatedAt.ToString("O"));
+            cmd.Parameters.AddWithValue("@last_accessed_at", entry.LastAccessedAt.ToString("O"));
+            cmd.Parameters.AddWithValue("@updated_at", entry.UpdatedAt.ToString("O"));
+            cmd.Parameters.AddWithValue("@embedding", EmbeddingToBlob(embedding));
+            cmd.ExecuteNonQuery();
+
+            // Insert into FTS index
+            using var ftsCmd = _connection.CreateCommand();
+            ftsCmd.Transaction = transaction;
+            ftsCmd.CommandText = """
+                INSERT OR REPLACE INTO memories_fts (rowid, content)
+                SELECT rowid, content FROM memories WHERE id = @id
+                """;
+            ftsCmd.Parameters.AddWithValue("@id", entry.Id);
+            ftsCmd.ExecuteNonQuery();
+
+            // Insert into vec table
+            try
+            {
+                using var vecCmd = _connection.CreateCommand();
+                vecCmd.Transaction = transaction;
+                vecCmd.CommandText = """
+                    INSERT OR REPLACE INTO memories_vec (id, embedding)
+                    VALUES (@id, @embedding)
+                    """;
+                vecCmd.Parameters.AddWithValue("@id", entry.Id);
+                vecCmd.Parameters.AddWithValue("@embedding", EmbeddingToBlob(embedding));
+                vecCmd.ExecuteNonQuery();
+            }
+            catch (SqliteException)
+            {
+                // vec table may not exist if extension unavailable
+            }
+
+            transaction.Commit();
+            _logger.LogDebug("Stored memory {Id} for agent {Agent}", entry.Id, entry.AgentName);
+        }
+        catch
+        {
+            transaction.Rollback();
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<RecalledMemory>> RecallByVectorAsync(
+        float[] queryEmbedding,
+        string agentName,
+        int topK,
+        float minScore,
+        CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+
+        // Try sqlite-vec first
+        try
+        {
+            return RecallByVecExtension(queryEmbedding, agentName, topK, minScore);
+        }
+        catch (SqliteException)
+        {
+            // Fallback to brute-force
+            return RecallByBruteForce(queryEmbedding, agentName, topK, minScore);
+        }
+    }
+
+    public async Task<IReadOnlyList<RecalledMemory>> RecallByKeywordAsync(
+        string query,
+        string agentName,
+        int topK,
+        CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+
+        var results = new List<RecalledMemory>();
+
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT m.id, m.content, m.type, m.trust_score
+            FROM memories_fts f
+            JOIN memories m ON m.rowid = f.rowid
+            WHERE memories_fts MATCH @query AND m.agent_name = @agent_name
+            ORDER BY rank
+            LIMIT @limit
+            """;
+        cmd.Parameters.AddWithValue("@query", query);
+        cmd.Parameters.AddWithValue("@agent_name", agentName);
+        cmd.Parameters.AddWithValue("@limit", topK);
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            results.Add(new RecalledMemory(
+                Id: reader.GetString(0),
+                Content: reader.GetString(1),
+                Type: (MemoryType)reader.GetInt32(2),
+                Score: 0.5f, // FTS doesn't give cosine score
+                TrustScore: reader.GetFloat(3)));
+        }
+
+        return results;
+    }
+
+    public async Task UpdateAccessAsync(string id, CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = """
+            UPDATE memories
+            SET access_count = access_count + 1,
+                last_accessed_at = @now,
+                trust_score = MIN(trust_score * 1.05, 2.0)
+            WHERE id = @id
+            """;
+        cmd.Parameters.AddWithValue("@id", id);
+        cmd.Parameters.AddWithValue("@now", DateTimeOffset.UtcNow.ToString("O"));
+        cmd.ExecuteNonQuery();
+    }
+
+    public async Task DecayAllAsync(float decayFactor = 0.95f, CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = """
+            UPDATE memories SET trust_score = trust_score * @decay, updated_at = @now
+            WHERE trust_score > 0.1
+            """;
+        cmd.Parameters.AddWithValue("@decay", decayFactor);
+        cmd.Parameters.AddWithValue("@now", DateTimeOffset.UtcNow.ToString("O"));
+        var affected = cmd.ExecuteNonQuery();
+
+        // Prune memories that decayed below threshold
+        using var pruneCmd = _connection.CreateCommand();
+        pruneCmd.CommandText = "DELETE FROM memories WHERE trust_score <= 0.1";
+        var pruned = pruneCmd.ExecuteNonQuery();
+
+        _logger.LogInformation("Memory decay applied: {Affected} memories decayed, {Pruned} pruned", affected, pruned);
+    }
+
+    public async Task<bool> HasSimilarAsync(float[] embedding, string agentName, float threshold = 0.92f, CancellationToken ct = default)
+    {
+        var results = await RecallByVectorAsync(embedding, agentName, 1, threshold, ct);
+        return results.Count > 0;
+    }
+
+    public async Task<int> GetCountAsync(string? agentName = null, CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = agentName is null
+            ? "SELECT COUNT(*) FROM memories"
+            : "SELECT COUNT(*) FROM memories WHERE agent_name = @agent_name";
+
+        if (agentName is not null)
+            cmd.Parameters.AddWithValue("@agent_name", agentName);
+
+        return Convert.ToInt32(cmd.ExecuteScalar());
+    }
+
+    private IReadOnlyList<RecalledMemory> RecallByVecExtension(
+        float[] queryEmbedding, string agentName, int topK, float minScore)
+    {
+        var results = new List<RecalledMemory>();
+
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT v.id, v.distance, m.content, m.type, m.trust_score
+            FROM memories_vec v
+            JOIN memories m ON m.id = v.id
+            WHERE v.embedding MATCH @embedding
+                AND k = @k
+                AND m.agent_name = @agent_name
+            ORDER BY v.distance
+            """;
+        cmd.Parameters.AddWithValue("@embedding", EmbeddingToBlob(queryEmbedding));
+        cmd.Parameters.AddWithValue("@k", topK * 2); // Over-fetch to filter by agent
+        cmd.Parameters.AddWithValue("@agent_name", agentName);
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read() && results.Count < topK)
+        {
+            var distance = reader.GetFloat(1);
+            var score = 1.0f - distance; // Convert distance to similarity
+            if (score < minScore) continue;
+
+            results.Add(new RecalledMemory(
+                Id: reader.GetString(0),
+                Content: reader.GetString(2),
+                Type: (MemoryType)reader.GetInt32(3),
+                Score: score,
+                TrustScore: reader.GetFloat(4)));
+        }
+
+        return results;
+    }
+
+    private IReadOnlyList<RecalledMemory> RecallByBruteForce(
+        float[] queryEmbedding, string agentName, int topK, float minScore)
+    {
+        var results = new List<(RecalledMemory Memory, float Score)>();
+
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT id, content, type, trust_score, embedding FROM memories WHERE agent_name = @agent_name";
+        cmd.Parameters.AddWithValue("@agent_name", agentName);
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            var storedEmbedding = BlobToEmbedding((byte[])reader["embedding"]);
+            var score = CosineSimilarity(queryEmbedding, storedEmbedding);
+            if (score < minScore) continue;
+
+            results.Add((new RecalledMemory(
+                Id: reader.GetString(0),
+                Content: reader.GetString(1),
+                Type: (MemoryType)reader.GetInt32(2),
+                Score: score,
+                TrustScore: reader.GetFloat(3)), score));
+        }
+
+        return results
+            .OrderByDescending(r => r.Score)
+            .Take(topK)
+            .Select(r => r.Memory)
+            .ToList();
+    }
+
+    private static float CosineSimilarity(float[] a, float[] b)
+    {
+        if (a.Length != b.Length) return 0;
+
+        float dot = 0, normA = 0, normB = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += a[i] * b[i];
+            normA += a[i] * a[i];
+            normB += b[i] * b[i];
+        }
+
+        var denom = MathF.Sqrt(normA) * MathF.Sqrt(normB);
+        return denom == 0 ? 0 : dot / denom;
+    }
+
+    private static byte[] EmbeddingToBlob(float[] embedding)
+    {
+        var bytes = new byte[embedding.Length * sizeof(float)];
+        Buffer.BlockCopy(embedding, 0, bytes, 0, bytes.Length);
+        return bytes;
+    }
+
+    private static float[] BlobToEmbedding(byte[] blob)
+    {
+        var floats = new float[blob.Length / sizeof(float)];
+        Buffer.BlockCopy(blob, 0, floats, 0, blob.Length);
+        return floats;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _connection.Dispose();
+    }
+}

--- a/SharpClaw/Program.cs
+++ b/SharpClaw/Program.cs
@@ -41,6 +41,7 @@ builder.Services.Configure<TelegramOptions>(builder.Configuration.GetSection(Tel
 builder.Services.Configure<OpenTelemetryOptions>(builder.Configuration.GetSection(OpenTelemetryOptions.SectionName));
 builder.Services.Configure<AnthropicOptions>(builder.Configuration.GetSection(AnthropicOptions.SectionName));
 builder.Services.Configure<AnthropicAdminMcpOptions>(builder.Configuration.GetSection(AnthropicAdminMcpOptions.SectionName));
+builder.Services.Configure<SemanticMemoryOptions>(builder.Configuration.GetSection(SemanticMemoryOptions.SectionName));
 
 // -- Logging: Console with custom format --
 builder.Logging.ClearProviders();
@@ -147,6 +148,19 @@ builder.Services.AddSingleton<ICommand, TicketCommand>();
 builder.Services.AddSingleton<MemoryService>();
 builder.Services.AddSingleton<AuditService>();
 builder.Services.AddSingleton<TranscriptService>();
+
+// -- Semantic Memory (conditional) --
+var semanticMemoryEnabled = builder.Configuration.GetValue<bool>("SemanticMemory:Enabled");
+if (semanticMemoryEnabled)
+{
+    builder.Services.AddSingleton<EmbeddingService>();
+    builder.Services.AddSingleton<SemanticMemoryStore>();
+    builder.Services.AddSingleton<SemanticMemoryService>();
+}
+else
+{
+    builder.Services.AddSingleton<SemanticMemoryService?>(sp => null);
+}
 
 // -- Workspace --
 builder.Services.AddSingleton<WorkspaceInitialiser>();

--- a/SharpClaw/SharpClaw.csproj
+++ b/SharpClaw/SharpClaw.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.7" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/SharpClaw/appsettings.json
+++ b/SharpClaw/appsettings.json
@@ -29,5 +29,15 @@
     "ApiKey": "",
     "DefaultModel": "claude-sonnet-4-20250514",
     "MaxTokens": 8192
+  },
+  "SemanticMemory": {
+    "Enabled": false,
+    "ModelPath": "models/all-MiniLM-L6-v2.onnx",
+    "TokenizerPath": "models/tokenizer.json",
+    "DatabasePath": "data/semantic-memory.db",
+    "TopK": 5,
+    "MinScore": 0.3,
+    "EmbeddingDimension": 384,
+    "MaxContextTokens": 1500
   }
 }

--- a/SharpClaw/scripts/download-embedding-model.sh
+++ b/SharpClaw/scripts/download-embedding-model.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Downloads the all-MiniLM-L6-v2 ONNX model for semantic memory embeddings.
+# Run from the repo root: ./SharpClaw/scripts/download-embedding-model.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+MODEL_DIR="$PROJECT_DIR/models"
+
+MODEL_URL="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx"
+TOKENIZER_URL="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
+
+echo "==> Downloading all-MiniLM-L6-v2 ONNX model..."
+echo "    Target: $MODEL_DIR"
+
+mkdir -p "$MODEL_DIR"
+
+if [ -f "$MODEL_DIR/all-MiniLM-L6-v2.onnx" ]; then
+    echo "    Model already exists, skipping download."
+else
+    echo "    Downloading model (~90MB)..."
+    curl -L --progress-bar -o "$MODEL_DIR/all-MiniLM-L6-v2.onnx" "$MODEL_URL"
+    echo "    ✓ Model downloaded."
+fi
+
+if [ -f "$MODEL_DIR/tokenizer.json" ]; then
+    echo "    Tokenizer already exists, skipping download."
+else
+    echo "    Downloading tokenizer..."
+    curl -L --progress-bar -o "$MODEL_DIR/tokenizer.json" "$TOKENIZER_URL"
+    echo "    ✓ Tokenizer downloaded."
+fi
+
+echo ""
+echo "==> Done! Model files:"
+ls -lh "$MODEL_DIR"/all-MiniLM-L6-v2.onnx "$MODEL_DIR"/tokenizer.json
+echo ""
+echo "Enable semantic memory in appsettings.json:"
+echo '  "SemanticMemory": { "Enabled": true }'

--- a/docs/docs/features/memory.md
+++ b/docs/docs/features/memory.md
@@ -52,3 +52,58 @@ This uses constructor injection (not `[FromServices]` — unsupported in ModelCo
 - **MemorySnapshotJob**: Daily archival of memory state
 - **LLM-based tagging**: Auto-generate tags for memory-index.md
 - **SQLite session persistence**: Store conversation history durably
+
+## Semantic Memory (Phase 1)
+
+Semantic memory adds vector-based recall to the existing file-based system. When enabled, the `AgentInvoker` automatically retrieves relevant stored memories before each LLM call and prepends them as context.
+
+### Architecture
+
+| Component | Responsibility |
+| --------- | -------------- |
+| `EmbeddingService` | Generates 384-dimensional embeddings using a local ONNX model (all-MiniLM-L6-v2) |
+| `SemanticMemoryStore` | SQLite-backed storage with FTS5 keyword search and brute-force cosine similarity (sqlite-vec optional) |
+| `SemanticMemoryService` | Orchestrates store + recall + deduplication + trust scoring |
+| `AgentInvoker` hook | Pre-LLM recall injection — recalled context is prepended to the user prompt |
+
+### Configuration
+
+Add to `appsettings.json`:
+
+```json
+{
+  "SemanticMemory": {
+    "Enabled": true,
+    "ModelPath": "models/all-MiniLM-L6-v2.onnx",
+    "TokenizerPath": "models/tokenizer.json",
+    "DatabasePath": "data/semantic-memory.db",
+    "TopK": 5,
+    "MinScore": 0.3,
+    "EmbeddingDimension": 384,
+    "MaxContextTokens": 1500
+  }
+}
+```
+
+Set `Enabled: true` to activate. The ONNX model file must be present at `ModelPath` (relative to app base directory).
+
+### Memory Types
+
+Stored memories have a type: `Fact`, `Decision`, `Preference`, or `Learning`.
+
+### Trust Scoring
+
+- Each memory starts with a trust score of 1.0
+- Recalled memories get a 5% boost (capped at 2.0)
+- Weekly decay (×0.95) prunes unused memories below 0.1
+
+### Deduplication
+
+Before storing, cosine similarity >0.92 against existing memories triggers a skip (prevents redundant entries).
+
+### Graceful Degradation
+
+- If `Enabled: false` (default), no semantic memory services are registered
+- If the ONNX model file is missing, startup fails with a clear error
+- If sqlite-vec is unavailable, falls back to brute-force cosine similarity
+- If recall fails at runtime, the prompt passes through unchanged


### PR DESCRIPTION
## Summary

Implements Phase 1 of ticket #007 (Native Semantic Memory). Adds vector-based semantic recall that automatically enriches agent prompts with relevant stored context.

## Components Added

- **`SemanticMemoryOptions`** — Configuration (disabled by default)
- **`EmbeddingService`** — Local ONNX embedding generation (MiniLM-L6-v2, 384d)
- **`SemanticMemoryStore`** — SQLite + FTS5 storage with cosine similarity search
- **`SemanticMemoryService`** — Orchestrator: recall, dedup (>0.92 cosine), trust scoring
- **`AgentInvoker` hook** — Pre-LLM recall injection (prepends context block to prompt)

## Design Decisions

- **Off by default**: `SemanticMemory:Enabled = false` — zero overhead when disabled
- **Graceful degradation**: sqlite-vec optional (brute-force fallback), recall failures swallowed
- **Conditional DI**: Services only registered when enabled; `SemanticMemoryService?` is nullable in AgentInvoker
- **Trust scoring**: Memories strengthen on access (+5%), decay weekly (×0.95), prune below 0.1

## Next Steps (Phase 2 & 3)

- Auto-capture: post-LLM extraction of facts/decisions via cheap LLM
- Decay scheduled job
- Import existing memory.md files
- Optional MCP tool for explicit recall

## Testing

- `dotnet build` ✅ (0 errors, 0 new warnings)
- `cd docs && npm run build` ✅