### PR TITLE
feat: Semantic Memory Phase 2 — Auto-Capture

### DIFF
--- a/SharpClaw/Configuration/SemanticMemoryOptions.cs
+++ b/SharpClaw/Configuration/SemanticMemoryOptions.cs
@@ -12,4 +12,11 @@ public sealed class SemanticMemoryOptions
     public float MinScore { get; set; } = 0.3f;
     public int EmbeddingDimension { get; set; } = 384;
     public int MaxContextTokens { get; set; } = 1500;
+
+    // Phase 2: Auto-capture extraction
+    public bool ExtractionEnabled { get; set; } = true;
+    public string ExtractionModel { get; set; } = "claude-haiku-4-20250414";
+    public int ExtractionMaxTokens { get; set; } = 1024;
+    public int MinPromptLengthForExtraction { get; set; } = 20;
+    public int MinResponseLengthForExtraction { get; set; } = 50;
 }

--- a/SharpClaw/Interactions/AgentInvoker.cs
+++ b/SharpClaw/Interactions/AgentInvoker.cs
@@ -18,6 +18,7 @@ public sealed class AgentInvoker(
     TranscriptService transcriptService,
     SchedulingContextAccessor schedulingContextAccessor,
     SemanticMemoryService? semanticMemory,
+    MemoryExtractionService? memoryExtraction,
     ILogger<AgentInvoker> logger)
 {
     public async Task<(string? SwitchedTo, string? ResponseText)> InvokeAsync(
@@ -180,6 +181,22 @@ public sealed class AgentInvoker(
 
         // Audit the response
         await auditService.LogAsync(session.AgentId, AuditEntryType.Response, responseText ?? string.Empty, ct);
+
+        // Fire-and-forget: extract and store memories from this exchange
+        if (result.Success && memoryExtraction is not null && !string.IsNullOrWhiteSpace(responseText))
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await memoryExtraction.ExtractAndStoreAsync(prompt, responseText, session.AgentId, CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Background memory extraction failed for agent {Agent}", session.AgentId);
+                }
+            }, CancellationToken.None);
+        }
 
         await session.PublishAsync(new AgentMessage(
             session.SessionId, Guid.NewGuid().ToString(),

--- a/SharpClaw/Memory/MemoryExtractionService.cs
+++ b/SharpClaw/Memory/MemoryExtractionService.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using Anthropic;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Memory;
+
+/// <summary>
+/// Extracts structured facts, decisions, and preferences from agent exchanges
+/// using a cheap LLM call, then stores them as semantic memories.
+/// </summary>
+public sealed class MemoryExtractionService(
+    IOptions<AnthropicOptions> anthropicOptions,
+    IOptions<SemanticMemoryOptions> memoryOptions,
+    SemanticMemoryService memoryService,
+    ILogger<MemoryExtractionService> logger)
+{
+    private readonly SemanticMemoryOptions _options = memoryOptions.Value;
+
+    private const string ExtractionPrompt = """
+        You are a memory extraction system. Analyse the following exchange between a user and an AI agent.
+        Extract important facts, decisions, preferences, and learnings that would be useful to remember for future conversations.
+
+        Rules:
+        - Only extract genuinely important, reusable information
+        - Skip transient details (timestamps, greetings, routine confirmations)
+        - Skip information that is only relevant to the immediate task at hand
+        - Each extracted memory should be a self-contained statement
+        - Categorise each as: fact, decision, preference, or learning
+        - Return JSON array only, no other text
+
+        Output format (JSON array):
+        [{"content": "...", "type": "fact|decision|preference|learning"}]
+
+        If nothing worth remembering, return: []
+
+        Exchange:
+        USER: {0}
+        AGENT: {1}
+        """;
+
+    public async Task ExtractAndStoreAsync(
+        string userPrompt,
+        string agentResponse,
+        string agentName,
+        CancellationToken ct = default)
+    {
+        if (!_options.ExtractionEnabled) return;
+        if (userPrompt.Length < _options.MinPromptLengthForExtraction) return;
+        if (agentResponse.Length < _options.MinResponseLengthForExtraction) return;
+
+        try
+        {
+            var extracted = await ExtractMemoriesAsync(userPrompt, agentResponse, ct);
+            if (extracted.Count == 0) return;
+
+            logger.LogDebug("Extracted {Count} memories from exchange for agent {Agent}", extracted.Count, agentName);
+
+            foreach (var memory in extracted)
+            {
+                await memoryService.StoreAsync(memory.Content, agentName, memory.Type, ct);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Memory extraction failed for agent {Agent}", agentName);
+        }
+    }
+
+    private async Task<IReadOnlyList<ExtractedMemory>> ExtractMemoriesAsync(
+        string userPrompt,
+        string agentResponse,
+        CancellationToken ct)
+    {
+        // Truncate long exchanges to avoid excessive extraction costs
+        var truncatedPrompt = Truncate(userPrompt, 2000);
+        var truncatedResponse = Truncate(agentResponse, 3000);
+
+        var prompt = string.Format(ExtractionPrompt, truncatedPrompt, truncatedResponse);
+
+        var client = new AnthropicClient { ApiKey = anthropicOptions.Value.ApiKey };
+        IChatClient chatClient = client.AsIChatClient(_options.ExtractionModel, _options.ExtractionMaxTokens);
+
+        try
+        {
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.User, prompt)
+            };
+
+            var response = await chatClient.GetResponseAsync(messages, cancellationToken: ct);
+            var text = response.Text?.Trim() ?? "[]";
+
+            return ParseExtractedMemories(text);
+        }
+        finally
+        {
+            if (chatClient is IAsyncDisposable disposable)
+                await disposable.DisposeAsync();
+        }
+    }
+
+    private static IReadOnlyList<ExtractedMemory> ParseExtractedMemories(string json)
+    {
+        // Strip markdown code fences if present
+        if (json.StartsWith("```"))
+        {
+            var firstNewline = json.IndexOf('\n');
+            var lastFence = json.LastIndexOf("```");
+            if (firstNewline >= 0 && lastFence > firstNewline)
+                json = json[(firstNewline + 1)..lastFence].Trim();
+        }
+
+        if (string.IsNullOrWhiteSpace(json) || json == "[]")
+            return [];
+
+        try
+        {
+            var items = JsonSerializer.Deserialize<List<ExtractedMemoryJson>>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            if (items is null) return [];
+
+            return items
+                .Where(i => !string.IsNullOrWhiteSpace(i.Content))
+                .Select(i => new ExtractedMemory(i.Content!, ParseType(i.Type)))
+                .ToList();
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static MemoryType ParseType(string? type) => type?.ToLowerInvariant() switch
+    {
+        "decision" => MemoryType.Decision,
+        "preference" => MemoryType.Preference,
+        "learning" => MemoryType.Learning,
+        _ => MemoryType.Fact
+    };
+
+    private static string Truncate(string text, int maxLength) =>
+        text.Length <= maxLength ? text : text[..maxLength] + "...";
+
+    private sealed record ExtractedMemory(string Content, MemoryType Type);
+
+    private sealed class ExtractedMemoryJson
+    {
+        public string? Content { get; set; }
+        public string? Type { get; set; }
+    }
+}

--- a/SharpClaw/Program.cs
+++ b/SharpClaw/Program.cs
@@ -151,15 +151,27 @@ builder.Services.AddSingleton<TranscriptService>();
 
 // -- Semantic Memory (conditional) --
 var semanticMemoryEnabled = builder.Configuration.GetValue<bool>("SemanticMemory:Enabled");
+var anthropicConfigured = !string.IsNullOrEmpty(builder.Configuration.GetValue<string>("Anthropic:ApiKey"));
 if (semanticMemoryEnabled)
 {
     builder.Services.AddSingleton<EmbeddingService>();
     builder.Services.AddSingleton<SemanticMemoryStore>();
     builder.Services.AddSingleton<SemanticMemoryService>();
+
+    // Extraction requires Anthropic API key
+    if (anthropicConfigured)
+    {
+        builder.Services.AddSingleton<MemoryExtractionService>();
+    }
+    else
+    {
+        builder.Services.AddSingleton<MemoryExtractionService?>(sp => null);
+    }
 }
 else
 {
     builder.Services.AddSingleton<SemanticMemoryService?>(sp => null);
+    builder.Services.AddSingleton<MemoryExtractionService?>(sp => null);
 }
 
 // -- Workspace --

--- a/SharpClaw/appsettings.json
+++ b/SharpClaw/appsettings.json
@@ -38,6 +38,11 @@
     "TopK": 5,
     "MinScore": 0.3,
     "EmbeddingDimension": 384,
-    "MaxContextTokens": 1500
+    "MaxContextTokens": 1500,
+    "ExtractionEnabled": true,
+    "ExtractionModel": "claude-haiku-4-20250414",
+    "ExtractionMaxTokens": 1024,
+    "MinPromptLengthForExtraction": 20,
+    "MinResponseLengthForExtraction": 50
   }
 }

--- a/docs/docs/features/memory.md
+++ b/docs/docs/features/memory.md
@@ -107,3 +107,65 @@ Before storing, cosine similarity >0.92 against existing memories triggers a ski
 - If the ONNX model file is missing, startup fails with a clear error
 - If sqlite-vec is unavailable, falls back to brute-force cosine similarity
 - If recall fails at runtime, the prompt passes through unchanged
+
+## Semantic Memory (Phase 2) — Auto-Capture
+
+Phase 2 adds automatic extraction of facts, decisions, preferences, and learnings from agent exchanges. After each successful LLM response, a background task uses a cheap model to analyse the exchange and store any noteworthy information as semantic memories.
+
+### Architecture
+
+| Component | Responsibility |
+| --------- | -------------- |
+| `MemoryExtractionService` | Calls a cheap LLM (Haiku) with the user prompt + agent response, parses extracted memories |
+| `AgentInvoker` post-LLM hook | Fire-and-forget: triggers extraction after a successful response without blocking the user |
+
+### How It Works
+
+1. User sends a prompt → agent responds successfully
+2. `AgentInvoker` fires a background task (non-blocking)
+3. `MemoryExtractionService` sends the exchange to a cheap model with a structured extraction prompt
+4. The model returns a JSON array of `{content, type}` objects
+5. Each extracted memory is stored via `SemanticMemoryService.StoreAsync()` — which handles embedding generation and deduplication (>0.92 cosine = skip)
+
+### Configuration
+
+```json
+{
+  "SemanticMemory": {
+    "Enabled": true,
+    "ExtractionEnabled": true,
+    "ExtractionModel": "claude-haiku-4-20250414",
+    "ExtractionMaxTokens": 1024,
+    "MinPromptLengthForExtraction": 20,
+    "MinResponseLengthForExtraction": 50
+  }
+}
+```
+
+| Setting | Default | Description |
+| ------- | ------- | ----------- |
+| `ExtractionEnabled` | `true` | Toggle extraction on/off (within enabled semantic memory) |
+| `ExtractionModel` | `claude-haiku-4-20250414` | Model used for extraction (should be cheap/fast) |
+| `ExtractionMaxTokens` | `1024` | Max output tokens for extraction response |
+| `MinPromptLengthForExtraction` | `20` | Skip extraction for very short prompts |
+| `MinResponseLengthForExtraction` | `50` | Skip extraction for very short responses |
+
+### Prerequisites
+
+- `SemanticMemory:Enabled` must be `true`
+- A valid `Anthropic:ApiKey` must be configured (extraction uses the Anthropic API)
+- If either is missing, extraction is silently disabled
+
+### Filtering
+
+The extraction prompt instructs the LLM to:
+- Only extract genuinely important, reusable information
+- Skip transient details (timestamps, greetings, routine confirmations)
+- Skip information only relevant to the immediate task
+- Categorise each memory as fact/decision/preference/learning
+
+### Graceful Degradation
+
+- Extraction failures are logged as warnings and never affect the user response
+- Fire-and-forget: the user response is returned immediately regardless of extraction status
+- Short exchanges (below length thresholds) are skipped entirely


### PR DESCRIPTION
## Summary

Implements Phase 2 of ticket #007 — automatic memory extraction from agent exchanges.

### What's New

- **`MemoryExtractionService`** — Uses a cheap LLM (Haiku) to extract facts, decisions, preferences, and learnings from user↔agent exchanges
- **Post-LLM capture hook** — Fire-and-forget in `AgentInvoker`: triggers extraction after every successful response without blocking the user
- **Configuration** — New options in `SemanticMemoryOptions`: extraction model, token limits, min length thresholds, enable/disable toggle
- **Conditional DI** — Extraction only registers when both `SemanticMemory:Enabled=true` AND `Anthropic:ApiKey` is configured

### How It Works

1. Agent responds to user prompt successfully
2. `AgentInvoker` fires background `Task.Run` (non-blocking)
3. `MemoryExtractionService` sends truncated exchange to Haiku with structured prompt
4. Returns JSON array of `{content, type}` objects
5. Each item stored via `SemanticMemoryService.StoreAsync()` (handles embedding + dedup)

### Safety

- Never blocks the user response path
- Extraction failures are logged as warnings, never surface to users
- Short exchanges (below configurable thresholds) are skipped
- Dedup (cosine > 0.92) prevents redundant entries
- Extraction prompt filters out transient/routine information

### Testing

- `dotnet build` — ✅ 0 errors
- `docs build` — ✅ passes

### Remaining (Phase 3)

- Trust decay scheduled job
- Import existing memory.md files
- Optional MCP tool for explicit recall