### PR TITLE
feat: Semantic Memory Phase 3 — Decay, Import & MCP Tools

### DIFF
--- a/SharpClaw/Mcp/SemanticMemoryMcpTools.cs
+++ b/SharpClaw/Mcp/SemanticMemoryMcpTools.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using SharpClaw.Memory;
+
+namespace SharpClaw.Mcp;
+
+public sealed class SemanticMemoryMcpTools(
+    SemanticMemoryService? semanticMemory,
+    MemoryImportService? importService)
+{
+    [McpServerTool]
+    [Description("Search semantic memory for relevant stored facts, decisions, preferences, and learnings. Returns the most relevant memories ranked by similarity.")]
+    public async Task<string> SemanticRecall(
+        [Description("The query text to search for relevant memories.")] string query,
+        [Description("Agent name to search memories for.")] string agentName,
+        [Description("Maximum number of results to return (default: 5).")] int? topK = null,
+        [Description("Minimum relevance score 0.0-1.0 (default: 0.3).")] float? minScore = null)
+    {
+        if (semanticMemory is null)
+            return "Semantic memory is not enabled. Set SemanticMemory:Enabled to true in configuration.";
+
+        var memories = await semanticMemory.RecallAsync(query, agentName, topK, minScore);
+
+        if (memories.Count == 0)
+            return "No relevant memories found.";
+
+        var results = memories.Select(m => new
+        {
+            m.Content,
+            Type = m.Type.ToString().ToLowerInvariant(),
+            Relevance = Math.Round(m.Score, 3),
+            Trust = Math.Round(m.TrustScore, 3)
+        });
+
+        return JsonSerializer.Serialize(results, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [McpServerTool]
+    [Description("Store a fact, decision, preference, or learning in semantic memory for future recall.")]
+    public async Task<string> SemanticStore(
+        [Description("The content to store as a memory.")] string content,
+        [Description("Agent name to store the memory for.")] string agentName,
+        [Description("Memory type: fact, decision, preference, or learning.")] string type = "fact")
+    {
+        if (semanticMemory is null)
+            return "Semantic memory is not enabled. Set SemanticMemory:Enabled to true in configuration.";
+
+        var memoryType = type.ToLowerInvariant() switch
+        {
+            "decision" => MemoryType.Decision,
+            "preference" => MemoryType.Preference,
+            "learning" => MemoryType.Learning,
+            _ => MemoryType.Fact
+        };
+
+        await semanticMemory.StoreAsync(content, agentName, memoryType);
+        return $"Stored {memoryType.ToString().ToLowerInvariant()} memory for agent '{agentName}'.";
+    }
+
+    [McpServerTool]
+    [Description("Get the count of stored semantic memories, optionally filtered by agent.")]
+    public async Task<string> SemanticMemoryCount(
+        [Description("Agent name to count memories for. Omit for total count across all agents.")] string? agentName = null)
+    {
+        if (semanticMemory is null)
+            return "Semantic memory is not enabled.";
+
+        var count = await semanticMemory.GetMemoryCountAsync(agentName);
+        return agentName is not null
+            ? $"Agent '{agentName}' has {count} semantic memories."
+            : $"Total semantic memories across all agents: {count}.";
+    }
+
+    [McpServerTool]
+    [Description("Import existing file-based memory (.md files) into semantic memory for an agent. Splits content into chunks and stores with deduplication.")]
+    public async Task<string> SemanticMemoryImport(
+        [Description("Agent name whose .md files to import. Use 'all' to import all agents.")] string agentName)
+    {
+        if (semanticMemory is null)
+            return "Semantic memory is not enabled.";
+
+        if (importService is null)
+            return "Memory import service is not available.";
+
+        if (agentName.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            var results = await importService.ImportAllAsync();
+            var summary = results.Select(kv =>
+                $"  {kv.Key}: {kv.Value.Stored}/{kv.Value.TotalChunks} stored ({kv.Value.Skipped} skipped/deduped)");
+            return $"Import complete:\n{string.Join("\n", summary)}";
+        }
+
+        var result = await importService.ImportAgentMemoryAsync(agentName);
+        return $"Import complete for '{agentName}': {result.Stored}/{result.TotalChunks} chunks stored ({result.Skipped} skipped/deduped).";
+    }
+}

--- a/SharpClaw/Memory/MemoryImportService.cs
+++ b/SharpClaw/Memory/MemoryImportService.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Memory;
+
+/// <summary>
+/// Imports existing file-based memory (*.md) into the semantic memory store.
+/// Splits content into paragraphs and stores each as a Fact memory.
+/// </summary>
+public sealed class MemoryImportService(
+    MemoryService fileMemory,
+    SemanticMemoryService semanticMemory,
+    IOptions<SharpClawOptions> sharpClawOptions,
+    ILogger<MemoryImportService> logger)
+{
+    /// <summary>
+    /// Import all .md files from an agent's memory directory into semantic memory.
+    /// Returns the number of memories stored (after dedup filtering).
+    /// </summary>
+    public async Task<ImportResult> ImportAgentMemoryAsync(string agentName, CancellationToken ct = default)
+    {
+        var agentDir = fileMemory.GetAgentMemoryPath(agentName);
+        if (!Directory.Exists(agentDir))
+        {
+            logger.LogWarning("No memory directory found for agent {Agent} at {Path}", agentName, agentDir);
+            return new ImportResult(0, 0, 0);
+        }
+
+        var files = Directory.GetFiles(agentDir, "*.md");
+        var totalChunks = 0;
+        var storedCount = 0;
+        var skippedCount = 0;
+
+        foreach (var file in files)
+        {
+            var fileName = Path.GetFileName(file);
+            // Skip audit files — they're append-only logs, not factual memory
+            if (fileName.Equals("audit.md", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var content = await File.ReadAllTextAsync(file, ct);
+            var chunks = SplitIntoChunks(content);
+
+            foreach (var chunk in chunks)
+            {
+                totalChunks++;
+                try
+                {
+                    await semanticMemory.StoreAsync(chunk, agentName, MemoryType.Fact, ct);
+                    storedCount++;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Failed to store chunk from {File} for agent {Agent}", fileName, agentName);
+                    skippedCount++;
+                }
+            }
+
+            logger.LogDebug("Imported {File} for agent {Agent}: {Chunks} chunks", fileName, agentName, chunks.Count);
+        }
+
+        logger.LogInformation(
+            "Import complete for agent {Agent}: {Files} files, {Total} chunks, {Stored} stored, {Skipped} skipped/deduped",
+            agentName, files.Length, totalChunks, storedCount, skippedCount);
+
+        return new ImportResult(totalChunks, storedCount, skippedCount);
+    }
+
+    /// <summary>
+    /// Import all agents' memory files from the workspace.
+    /// </summary>
+    public async Task<Dictionary<string, ImportResult>> ImportAllAsync(CancellationToken ct = default)
+    {
+        var workspacePath = sharpClawOptions.Value.WorkspacePath;
+        var results = new Dictionary<string, ImportResult>();
+
+        if (!Directory.Exists(workspacePath))
+        {
+            logger.LogWarning("Workspace path not found: {Path}", workspacePath);
+            return results;
+        }
+
+        var agentDirs = Directory.GetDirectories(workspacePath)
+            .Where(d => !Path.GetFileName(d).Equals("knowledge", StringComparison.OrdinalIgnoreCase))
+            .Where(d => !Path.GetFileName(d).Equals("projects", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var dir in agentDirs)
+        {
+            var agentName = Path.GetFileName(dir);
+            var result = await ImportAgentMemoryAsync(agentName, ct);
+            results[agentName] = result;
+        }
+
+        return results;
+    }
+
+    private static IReadOnlyList<string> SplitIntoChunks(string content)
+    {
+        var chunks = new List<string>();
+
+        // Split by double newline (paragraphs) or markdown headers
+        var paragraphs = content.Split(["\n\n", "\r\n\r\n"], StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var para in paragraphs)
+        {
+            var trimmed = para.Trim();
+
+            // Skip very short content (headers alone, blank lines, etc.)
+            if (trimmed.Length < 30) continue;
+
+            // Skip markdown headers that are just structural
+            if (trimmed.StartsWith('#') && !trimmed.Contains('\n')) continue;
+
+            // Cap chunk size — split long paragraphs at sentence boundaries
+            if (trimmed.Length > 500)
+            {
+                var sentences = SplitIntoSentences(trimmed);
+                var buffer = "";
+                foreach (var sentence in sentences)
+                {
+                    if (buffer.Length + sentence.Length > 500 && buffer.Length > 0)
+                    {
+                        chunks.Add(buffer.Trim());
+                        buffer = "";
+                    }
+                    buffer += sentence + " ";
+                }
+                if (buffer.Trim().Length >= 30)
+                    chunks.Add(buffer.Trim());
+            }
+            else
+            {
+                chunks.Add(trimmed);
+            }
+        }
+
+        return chunks;
+    }
+
+    private static IReadOnlyList<string> SplitIntoSentences(string text)
+    {
+        var sentences = new List<string>();
+        var current = 0;
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] is '.' or '!' or '?' && i + 1 < text.Length && char.IsWhiteSpace(text[i + 1]))
+            {
+                sentences.Add(text[current..(i + 1)]);
+                current = i + 2;
+            }
+        }
+
+        if (current < text.Length)
+            sentences.Add(text[current..]);
+
+        return sentences;
+    }
+}
+
+public sealed record ImportResult(int TotalChunks, int Stored, int Skipped);

--- a/SharpClaw/Program.cs
+++ b/SharpClaw/Program.cs
@@ -157,6 +157,8 @@ if (semanticMemoryEnabled)
     builder.Services.AddSingleton<EmbeddingService>();
     builder.Services.AddSingleton<SemanticMemoryStore>();
     builder.Services.AddSingleton<SemanticMemoryService>();
+    builder.Services.AddSingleton<MemoryImportService>();
+    builder.Services.AddHostedService<MemoryDecayWorker>();
 
     // Extraction requires Anthropic API key
     if (anthropicConfigured)
@@ -172,6 +174,7 @@ else
 {
     builder.Services.AddSingleton<SemanticMemoryService?>(sp => null);
     builder.Services.AddSingleton<MemoryExtractionService?>(sp => null);
+    builder.Services.AddSingleton<MemoryImportService?>(sp => null);
 }
 
 // -- Workspace --
@@ -181,6 +184,7 @@ builder.Services.AddSingleton<WorkspaceInitialiser>();
 builder.Services.AddMcpServer()
     .WithHttpTransport()
     .WithTools<MemoryMcpTools>()
+    .WithTools<SemanticMemoryMcpTools>()
     .WithTools<AnthropicAdminMcpTools>();
 
 // -- Telegram --

--- a/SharpClaw/Workers/MemoryDecayWorker.cs
+++ b/SharpClaw/Workers/MemoryDecayWorker.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+using SharpClaw.Memory;
+
+namespace SharpClaw.Workers;
+
+/// <summary>
+/// Runs weekly trust decay on semantic memories and prunes those below threshold.
+/// </summary>
+public sealed class MemoryDecayWorker(
+    SemanticMemoryService memoryService,
+    IOptions<SemanticMemoryOptions> options,
+    ILogger<MemoryDecayWorker> logger) : BackgroundService
+{
+    private static readonly TimeSpan DecayInterval = TimeSpan.FromDays(7);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!options.Value.Enabled)
+        {
+            logger.LogInformation("Memory decay worker disabled (SemanticMemory not enabled)");
+            return;
+        }
+
+        logger.LogInformation("Memory decay worker started — running every {Days} days", DecayInterval.TotalDays);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(DecayInterval, stoppingToken);
+                await RunDecayAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error in memory decay tick");
+            }
+        }
+
+        logger.LogInformation("Memory decay worker stopped");
+    }
+
+    private async Task RunDecayAsync(CancellationToken ct)
+    {
+        var countBefore = await memoryService.GetMemoryCountAsync(ct: ct);
+        await memoryService.DecayAsync(ct);
+        var countAfter = await memoryService.GetMemoryCountAsync(ct: ct);
+
+        logger.LogInformation(
+            "Memory decay complete: {Before} memories before, {After} after ({Pruned} pruned)",
+            countBefore, countAfter, countBefore - countAfter);
+    }
+}

--- a/docs/docs/features/memory.md
+++ b/docs/docs/features/memory.md
@@ -169,3 +169,63 @@ The extraction prompt instructs the LLM to:
 - Extraction failures are logged as warnings and never affect the user response
 - Fire-and-forget: the user response is returned immediately regardless of extraction status
 - Short exchanges (below length thresholds) are skipped entirely
+
+## Semantic Memory (Phase 3) — Maintenance & MCP Tools
+
+Phase 3 adds trust decay, memory import, and explicit MCP tools for agents to interact with semantic memory directly.
+
+### Trust Decay Worker
+
+`MemoryDecayWorker` is a `BackgroundService` that runs every 7 days:
+
+1. Applies a 0.95× decay multiplier to all memory trust scores
+2. Prunes memories that fall below 0.1 (effectively forgotten)
+3. Logs count of decayed and pruned memories
+
+This ensures rarely-accessed memories gradually fade while frequently-recalled ones stay strong (boosted 5% on each recall, capped at 2.0).
+
+### Memory Import
+
+`MemoryImportService` imports existing file-based memory (`.md` files) into the semantic memory store:
+
+- Splits content into paragraph-sized chunks (30–500 chars)
+- Skips `audit.md` files (append-only logs, not factual memory)
+- Deduplication via cosine similarity (>0.92 = skip)
+- Available per-agent or for all agents at once
+
+Trigger via the `semantic_memory_import` MCP tool or programmatically.
+
+### MCP Tools
+
+Four new MCP tools are exposed via `SemanticMemoryMcpTools`:
+
+| Tool | Description |
+| ---- | ----------- |
+| `semantic_recall` | Search semantic memory by natural language query |
+| `semantic_store` | Explicitly store a fact/decision/preference/learning |
+| `semantic_memory_count` | Get count of stored memories (per-agent or total) |
+| `semantic_memory_import` | Import .md files into semantic memory |
+
+These tools are always registered but return helpful error messages when semantic memory is disabled.
+
+### Full Configuration Reference
+
+```json
+{
+  "SemanticMemory": {
+    "Enabled": true,
+    "ModelPath": "models/all-MiniLM-L6-v2.onnx",
+    "TokenizerPath": "models/tokenizer.json",
+    "DatabasePath": "data/semantic-memory.db",
+    "TopK": 5,
+    "MinScore": 0.3,
+    "EmbeddingDimension": 384,
+    "MaxContextTokens": 1500,
+    "ExtractionEnabled": true,
+    "ExtractionModel": "claude-haiku-4-20250414",
+    "ExtractionMaxTokens": 1024,
+    "MinPromptLengthForExtraction": 20,
+    "MinResponseLengthForExtraction": 50
+  }
+}
+```


### PR DESCRIPTION
## Summary

Completes ticket #007 — implements the final phase of native semantic memory.

### What's New

**1. Trust Decay Worker** (`MemoryDecayWorker`)
- `BackgroundService` that runs every 7 days
- Applies 0.95× decay to all trust scores
- Prunes memories below 0.1 threshold
- Logs before/after counts

**2. Memory Import** (`MemoryImportService`)
- Imports existing `.md` files into semantic memory store
- Splits into paragraph-sized chunks (30–500 chars)
- Skips `audit.md` (append-only logs)
- Per-agent or bulk import for all agents
- Dedup respected (cosine > 0.92 = skip)

**3. MCP Tools** (`SemanticMemoryMcpTools`)
| Tool | Purpose |
|------|---------|
| `semantic_recall` | Natural language search over stored memories |
| `semantic_store` | Explicitly store a memory |
| `semantic_memory_count` | Count memories per agent or total |
| `semantic_memory_import` | Import .md files into semantic store |

### DI Registration
- `MemoryImportService` — registered when semantic memory enabled
- `MemoryDecayWorker` — hosted service when semantic memory enabled
- `SemanticMemoryMcpTools` — always registered (returns error messages when disabled)
- Null registrations for `MemoryImportService?` when disabled

### Testing
- `dotnet build` — ✅ 0 errors
- `docs build` — ✅ passes

### Ticket #007 Complete
All three phases delivered:
- Phase 1: Foundation (embeddings, store, recall hook) ✅
- Phase 2: Auto-capture (extraction service, fire-and-forget hook) ✅
- Phase 3: Maintenance (decay, import, MCP tools) ✅