### PR TITLE
Fix TranscriptService NullReferenceException and vocab.txt output copy

### DIFF
--- a/SharpClaw/Auditing/TranscriptService.cs
+++ b/SharpClaw/Auditing/TranscriptService.cs
@@ -14,12 +14,15 @@ public sealed class TranscriptService(IOptions<SharpClawOptions> options, ILogge
         string agentName,
         string sessionId,
         string turnType,
-        string content,
+        string? content,
         TranscriptMetadata? metadata = null,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(_workspaceRoot))
             return Task.CompletedTask;
+
+        if (string.IsNullOrEmpty(content))
+            content = string.Empty;
 
         var safeAgentName = SanitizePathSegment(agentName);
         var safeSessionId = SanitizePathSegment(sessionId);

--- a/SharpClaw/SharpClaw.csproj
+++ b/SharpClaw/SharpClaw.csproj
@@ -33,6 +33,7 @@
     <Content Include="agents/**/*.agent.md" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="skills/**/*.skill.md" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="models/**/*.onnx" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="models/**/*.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Update="mcps/**/*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

Two issues found in Loki logs:

1. **TranscriptService NullReferenceException** (17:23 UTC) — `content.Length` throws when `content` is null. This happens when a web API request passes a null message body.

2. **Hosting failed to start** (17:36 UTC) — `vocab.txt` not found at runtime. The `.csproj` only copied `models/**/*.onnx` to the output directory, missing the WordPiece vocabulary file needed by the tokenizer.

## Fix

- `TranscriptService.LogAsync`: changed `content` parameter to `string?` and coalesce to `string.Empty` early
- `SharpClaw.csproj`: added `models/**/*.txt` to Content items with `CopyToOutputDirectory=PreserveNewest`

## Verification

- Build succeeds
- `vocab.txt` confirmed present in `bin/Debug/net10.0/models/` after build