### PR TITLE
Add SharpClaw client identity to outbound MCP connections

### DIFF
--- a/SharpClaw/Execution/LazyMcpActivationTool.cs
+++ b/SharpClaw/Execution/LazyMcpActivationTool.cs
@@ -74,7 +74,7 @@ public sealed class LazyMcpActivationTool : AIFunction, IAsyncDisposable
                 _ => throw new InvalidOperationException($"Unknown MCP transport '{_definition.Transport}' for server '{_serverName}'")
             };
 
-            _client = await McpClient.CreateAsync(transport, loggerFactory: _loggerFactory, cancellationToken: cancellationToken);
+            _client = await McpClient.CreateAsync(transport, McpToolBridge.DefaultClientOptions, loggerFactory: _loggerFactory, cancellationToken: cancellationToken);
             var tools = await _client.ListToolsAsync(cancellationToken: cancellationToken);
 
             // Inject discovered tools into the session's live tool list

--- a/SharpClaw/Execution/McpToolBridge.cs
+++ b/SharpClaw/Execution/McpToolBridge.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using ModelContextProtocol.Client;
 using SharpClaw.Models;
 
@@ -5,6 +6,15 @@ namespace SharpClaw.Execution;
 
 public sealed class McpToolBridge : IAsyncDisposable
 {
+    internal static readonly McpClientOptions DefaultClientOptions = new()
+    {
+        ClientInfo = new()
+        {
+            Name = "SharpClaw",
+            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.0"
+        }
+    };
+
     private readonly List<McpClient> _clients = [];
 
     public IReadOnlyList<McpClientTool> Tools { get; private set; } = [];
@@ -36,7 +46,7 @@ public sealed class McpToolBridge : IAsyncDisposable
                     _ => throw new InvalidOperationException($"Unknown MCP transport type '{def.Transport}' for server '{name}'")
                 };
 
-                var client = await McpClient.CreateAsync(transport, loggerFactory: loggerFactory, cancellationToken: ct);
+                var client = await McpClient.CreateAsync(transport, DefaultClientOptions, loggerFactory: loggerFactory, cancellationToken: ct);
                 bridge._clients.Add(client);
 
                 var tools = await client.ListToolsAsync(cancellationToken: ct);


### PR DESCRIPTION
## Context

When debugging MCP tool errors in Loki, the client shows as generic defaults (e.g. 'curl 1.0'). This makes it hard to distinguish SharpClaw's own MCP client calls from external clients.

## Change

Pass `McpClientOptions` with `ClientInfo = { Name = "SharpClaw", Version = "<assembly version>" }` to all `McpClient.CreateAsync` calls:

- `McpToolBridge` (eager connections)
- `LazyMcpActivationTool` (deferred connections)

Now logs will show `Client (SharpClaw 1.0.0.0)` instead of generic defaults, making it easy to identify our own calls vs external clients hitting the MCP server.