### PR TITLE
Add labels, reporter, and assignee to tickets (ticket #008)

### DIFF
--- a/SharpClaw.Web/src/api/projects.ts
+++ b/SharpClaw.Web/src/api/projects.ts
@@ -14,8 +14,17 @@ export interface TicketSummary {
     title: string;
     description: string | null;
     status: string;
+    labels: string[];
+    reporter: string | null;
+    assignee: string | null;
     createdAt: string;
     updatedAt: string;
+}
+
+export interface User {
+    id: string;
+    name: string;
+    type: 'agent' | 'human';
 }
 
 export const getProjects = () => apiFetch<ProjectSummary[]>('/projects');
@@ -23,13 +32,15 @@ export const getProjects = () => apiFetch<ProjectSummary[]>('/projects');
 export const getProjectTickets = (projectId: string) =>
     apiFetch<TicketSummary[]>(`/projects/${projectId}/tickets`);
 
-export const createTicket = (projectId: string, data: { title: string; description?: string }) =>
+export const getUsers = () => apiFetch<User[]>('/users');
+
+export const createTicket = (projectId: string, data: { title: string; description?: string; reporter?: string; assignee?: string; labels?: string[] }) =>
     apiFetch<TicketSummary>(`/projects/${projectId}/tickets`, {
         method: 'POST',
         body: JSON.stringify(data),
     });
 
-export const updateTicket = (projectId: string, ticketId: string, data: { title?: string; description?: string; status?: string }) =>
+export const updateTicket = (projectId: string, ticketId: string, data: { title?: string; description?: string; status?: string; assignee?: string; labels?: string[] }) =>
     apiFetch<TicketSummary>(`/projects/${projectId}/tickets/${ticketId}`, {
         method: 'PATCH',
         body: JSON.stringify(data),

--- a/SharpClaw.Web/src/pages/ProjectsPage.tsx
+++ b/SharpClaw.Web/src/pages/ProjectsPage.tsx
@@ -16,8 +16,8 @@ import IconButton from '@mui/material/IconButton';
 import AddIcon from '@mui/icons-material/Add';
 import MenuItem from '@mui/material/MenuItem';
 import Editor from '@monaco-editor/react';
-import { getProjects, getProjectTickets, updateTicketStatus, updateTicket, createTicket, improveTicket } from '../api/projects';
-import type { ProjectSummary, TicketSummary } from '../api/projects';
+import { getProjects, getProjectTickets, getUsers, updateTicketStatus, updateTicket, createTicket, improveTicket } from '../api/projects';
+import type { ProjectSummary, TicketSummary, User } from '../api/projects';
 
 const STATUSES = [
     { key: 'idea', label: 'Idea' },
@@ -40,18 +40,22 @@ function getProjectColour(projectId: string, projects: ProjectSummary[]): string
 export default function ProjectsPage() {
     const [projects, setProjects] = useState<ProjectSummary[]>([]);
     const [tickets, setTickets] = useState<TicketSummary[]>([]);
+    const [users, setUsers] = useState<User[]>([]);
     const [draggedTicketId, setDraggedTicketId] = useState<string | null>(null);
     const [dragOverStatus, setDragOverStatus] = useState<string | null>(null);
     const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+    const [selectedAssignee, setSelectedAssignee] = useState<string | null>(null);
     const [editingTicket, setEditingTicket] = useState<TicketSummary | null>(null);
     const [editTitle, setEditTitle] = useState('');
     const [editDescription, setEditDescription] = useState('');
+    const [editAssignee, setEditAssignee] = useState('');
     const [saving, setSaving] = useState(false);
     const [improving, setImproving] = useState(false);
     const [creatingTicket, setCreatingTicket] = useState(false);
     const [newTicketTitle, setNewTicketTitle] = useState('');
     const [newTicketDescription, setNewTicketDescription] = useState('');
     const [newTicketProjectId, setNewTicketProjectId] = useState('');
+    const [newTicketAssignee, setNewTicketAssignee] = useState('');
     const [savingNew, setSavingNew] = useState(false);
 
     useEffect(() => {
@@ -62,6 +66,7 @@ export default function ProjectsPage() {
             );
             setTickets(allTickets.flat());
         });
+        getUsers().then(setUsers);
     }, []);
 
     const handleDragStart = useCallback((e: DragEvent, ticketId: string) => {
@@ -111,6 +116,7 @@ export default function ProjectsPage() {
         setEditingTicket(ticket);
         setEditTitle(ticket.title);
         setEditDescription(ticket.description ?? '');
+        setEditAssignee(ticket.assignee ?? '');
     }, []);
 
     const handleEditorClose = useCallback(() => {
@@ -121,9 +127,10 @@ export default function ProjectsPage() {
         if (!editingTicket) return;
         setSaving(true);
         try {
-            const data: { title?: string; description?: string } = {};
+            const data: { title?: string; description?: string; assignee?: string } = {};
             if (editTitle !== editingTicket.title) data.title = editTitle;
             if (editDescription !== (editingTicket.description ?? '')) data.description = editDescription;
+            if (editAssignee !== (editingTicket.assignee ?? '')) data.assignee = editAssignee || undefined;
 
             if (Object.keys(data).length > 0) {
                 const updated = await updateTicket(editingTicket.projectId, editingTicket.id, data);
@@ -133,7 +140,7 @@ export default function ProjectsPage() {
         } finally {
             setSaving(false);
         }
-    }, [editingTicket, editTitle, editDescription]);
+    }, [editingTicket, editTitle, editDescription, editAssignee]);
 
     const handleImprove = useCallback(async () => {
         if (!editingTicket) return;
@@ -150,6 +157,7 @@ export default function ProjectsPage() {
         setNewTicketTitle('');
         setNewTicketDescription('');
         setNewTicketProjectId(selectedProjectId ?? projects[0]?.id ?? '');
+        setNewTicketAssignee('');
         setCreatingTicket(true);
     }, [selectedProjectId, projects]);
 
@@ -160,17 +168,22 @@ export default function ProjectsPage() {
             const ticket = await createTicket(newTicketProjectId, {
                 title: newTicketTitle.trim(),
                 description: newTicketDescription.trim() || undefined,
+                assignee: newTicketAssignee || undefined,
             });
             setTickets(prev => [...prev, ticket]);
             setCreatingTicket(false);
         } finally {
             setSavingNew(false);
         }
-    }, [newTicketProjectId, newTicketTitle, newTicketDescription]);
+    }, [newTicketProjectId, newTicketTitle, newTicketDescription, newTicketAssignee]);
 
-    const filteredTickets = selectedProjectId
-        ? tickets.filter(t => t.projectId === selectedProjectId)
-        : tickets;
+    const filteredTickets = tickets.filter(t => {
+        if (selectedProjectId && t.projectId !== selectedProjectId && !t.labels.includes(selectedProjectId))
+            return false;
+        if (selectedAssignee && t.assignee !== selectedAssignee)
+            return false;
+        return true;
+    });
 
     const ticketsByStatus = (status: string) =>
         filteredTickets.filter(t => t.status === status);
@@ -219,6 +232,33 @@ export default function ProjectsPage() {
                                     color: PROJECT_COLOURS[idx % PROJECT_COLOURS.length],
                                 }),
                             }}
+                        />
+                    ))}
+                </Stack>
+            )}
+
+            {users.length > 0 && (
+                <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap', gap: 0.5 }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center', mr: 0.5 }}>
+                        Assignee:
+                    </Typography>
+                    <Chip
+                        label="All"
+                        size="small"
+                        variant={selectedAssignee === null ? 'filled' : 'outlined'}
+                        color={selectedAssignee === null ? 'primary' : 'default'}
+                        onClick={() => setSelectedAssignee(null)}
+                    />
+                    {users.map((user) => (
+                        <Chip
+                            key={user.id}
+                            label={user.name}
+                            size="small"
+                            variant={selectedAssignee === user.id ? 'filled' : 'outlined'}
+                            color={selectedAssignee === user.id ? 'primary' : 'default'}
+                            onClick={() => setSelectedAssignee(
+                                selectedAssignee === user.id ? null : user.id
+                            )}
                         />
                     ))}
                 </Stack>
@@ -274,16 +314,40 @@ export default function ProjectsPage() {
                                         <Typography variant="body2" sx={{ fontWeight: 500, mb: 0.75 }}>
                                             {ticket.title}
                                         </Typography>
-                                        <Chip
-                                            label={projects.find(p => p.id === ticket.projectId)?.title ?? ticket.projectId}
-                                            size="small"
-                                            sx={{
-                                                bgcolor: getProjectColour(ticket.projectId, projects),
-                                                color: '#fff',
-                                                fontWeight: 500,
-                                                fontSize: '0.7rem',
-                                            }}
-                                        />
+                                        <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', flexWrap: 'wrap', gap: 0.5 }}>
+                                            <Chip
+                                                label={projects.find(p => p.id === ticket.projectId)?.title ?? ticket.projectId}
+                                                size="small"
+                                                sx={{
+                                                    bgcolor: getProjectColour(ticket.projectId, projects),
+                                                    color: '#fff',
+                                                    fontWeight: 500,
+                                                    fontSize: '0.7rem',
+                                                }}
+                                            />
+                                            {ticket.labels.filter(l => l !== ticket.projectId).map((label) => (
+                                                <Chip
+                                                    key={label}
+                                                    label={projects.find(p => p.id === label)?.title ?? label}
+                                                    size="small"
+                                                    sx={{
+                                                        bgcolor: getProjectColour(label, projects),
+                                                        color: '#fff',
+                                                        fontWeight: 500,
+                                                        fontSize: '0.7rem',
+                                                        opacity: 0.75,
+                                                    }}
+                                                />
+                                            ))}
+                                            {ticket.assignee && (
+                                                <Chip
+                                                    label={ticket.assignee}
+                                                    size="small"
+                                                    variant="outlined"
+                                                    sx={{ fontSize: '0.7rem' }}
+                                                />
+                                            )}
+                                        </Stack>
                                     </CardContent>
                                 </Card>
                             ))}
@@ -306,6 +370,26 @@ export default function ProjectsPage() {
                         fullWidth
                         slotProps={{ input: { sx: { fontSize: '1.25rem', fontWeight: 600 } } }}
                     />
+                    <Stack direction="row" spacing={2} sx={{ mt: 1, alignItems: 'center' }}>
+                        {editingTicket?.reporter && (
+                            <Typography variant="caption" color="text.secondary">
+                                Reporter: {editingTicket.reporter}
+                            </Typography>
+                        )}
+                        <TextField
+                            select
+                            label="Assignee"
+                            value={editAssignee}
+                            onChange={(e) => setEditAssignee(e.target.value)}
+                            size="small"
+                            sx={{ minWidth: 150 }}
+                        >
+                            <MenuItem value="">Unassigned</MenuItem>
+                            {users.map((u) => (
+                                <MenuItem key={u.id} value={u.id}>{u.name}</MenuItem>
+                            ))}
+                        </TextField>
+                    </Stack>
                 </DialogTitle>
                 <DialogContent sx={{ p: 0, height: 450 }}>
                     <Editor
@@ -356,6 +440,19 @@ export default function ProjectsPage() {
                         fullWidth
                         autoFocus
                     />
+                    <TextField
+                        select
+                        label="Assignee"
+                        value={newTicketAssignee}
+                        onChange={(e) => setNewTicketAssignee(e.target.value)}
+                        fullWidth
+                        size="small"
+                    >
+                        <MenuItem value="">Unassigned</MenuItem>
+                        {users.map((u) => (
+                            <MenuItem key={u.id} value={u.id}>{u.name}</MenuItem>
+                        ))}
+                    </TextField>
                     <Box sx={{ height: 300 }}>
                         <Editor
                             height="100%"

--- a/SharpClaw/Api/ProjectEndpoints.cs
+++ b/SharpClaw/Api/ProjectEndpoints.cs
@@ -1,3 +1,4 @@
+using SharpClaw.Abstractions;
 using SharpClaw.Execution;
 using SharpClaw.Loading;
 using SharpClaw.Models;
@@ -9,6 +10,14 @@ internal static class ProjectEndpoints
     public static void MapProjectEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/projects").WithTags("Projects");
+
+        // Users (agents + configured humans) for assignment dropdowns
+        app.MapGet("/api/users", (IAgentRegistry agentRegistry) =>
+        {
+            var agents = agentRegistry.GetAll().Select(a => new { id = a.Name, name = a.Name, type = "agent" });
+            var humans = new[] { new { id = "kevin", name = "Kevin", type = "human" } };
+            return humans.Concat(agents);
+        }).WithTags("Users");
 
         group.MapGet("/", (ProjectLoader loader) =>
             loader.GetAllProjects().Select(p => new
@@ -77,6 +86,9 @@ internal static class ProjectEndpoints
                 t.Title,
                 t.Description,
                 Status = t.Status.ToFrontmatterValue(),
+                t.Labels,
+                t.Reporter,
+                t.Assignee,
                 t.CreatedAt,
                 t.UpdatedAt,
             });
@@ -94,6 +106,9 @@ internal static class ProjectEndpoints
                 ticket.Title,
                 ticket.Description,
                 Status = ticket.Status.ToFrontmatterValue(),
+                ticket.Labels,
+                ticket.Reporter,
+                ticket.Assignee,
                 ticket.CreatedAt,
                 ticket.UpdatedAt,
             });
@@ -106,7 +121,7 @@ internal static class ProjectEndpoints
 
             try
             {
-                var ticket = loader.CreateTicket(projectId, req.Title, req.Description);
+                var ticket = loader.CreateTicket(projectId, req.Title, req.Description, req.Reporter, req.Assignee, req.Labels);
                 return Results.Created($"/api/projects/{projectId}/tickets/{ticket.Id}", new
                 {
                     ticket.Id,
@@ -114,6 +129,9 @@ internal static class ProjectEndpoints
                     ticket.Title,
                     ticket.Description,
                     Status = ticket.Status.ToFrontmatterValue(),
+                    ticket.Labels,
+                    ticket.Reporter,
+                    ticket.Assignee,
                     ticket.CreatedAt,
                     ticket.UpdatedAt,
                 });
@@ -127,7 +145,8 @@ internal static class ProjectEndpoints
         group.MapPatch("/{projectId}/tickets/{ticketId}", (string projectId, string ticketId, UpdateTicketRequest req, ProjectLoader loader) =>
         {
             var status = string.IsNullOrEmpty(req.Status) ? null : (TicketStatus?)TicketStatusExtensions.ParseStatus(req.Status);
-            var updated = loader.UpdateTicket(projectId, ticketId, status, req.Title, req.Description);
+            var labels = req.Labels is not null ? (IReadOnlyList<string>)req.Labels : null;
+            var updated = loader.UpdateTicket(projectId, ticketId, status, req.Title, req.Description, req.Assignee, labels);
 
             if (updated is null) return Results.NotFound();
 
@@ -138,6 +157,9 @@ internal static class ProjectEndpoints
                 updated.Title,
                 updated.Description,
                 Status = updated.Status.ToFrontmatterValue(),
+                updated.Labels,
+                updated.Reporter,
+                updated.Assignee,
                 updated.CreatedAt,
                 updated.UpdatedAt,
             });
@@ -186,6 +208,6 @@ internal static class ProjectEndpoints
     }
 
     private sealed record CreateProjectRequest(string Title, string? Description);
-    private sealed record CreateTicketRequest(string Title, string? Description);
-    private sealed record UpdateTicketRequest(string? Title, string? Description, string? Status);
+    private sealed record CreateTicketRequest(string Title, string? Description, string? Reporter, string? Assignee, string[]? Labels);
+    private sealed record UpdateTicketRequest(string? Title, string? Description, string? Status, string? Assignee, string[]? Labels);
 }

--- a/SharpClaw/Loading/ProjectLoader.cs
+++ b/SharpClaw/Loading/ProjectLoader.cs
@@ -91,7 +91,7 @@ public sealed class ProjectLoader(
         return ParseTicket(projectId, file);
     }
 
-    public Ticket CreateTicket(string projectId, string title, string? description)
+    public Ticket CreateTicket(string projectId, string title, string? description, string? reporter = null, string? assignee = null, IReadOnlyList<string>? labels = null)
     {
         var ticketsDir = Path.Combine(ProjectsDir, projectId, "tickets");
         if (!Directory.Exists(ticketsDir))
@@ -99,7 +99,7 @@ public sealed class ProjectLoader(
 
         var nextId = GetNextTicketId(ticketsDir);
         var now = DateTimeOffset.UtcNow;
-        var ticket = new Ticket(nextId, projectId, title, description, TicketStatus.Planning, now, now);
+        var ticket = new Ticket(nextId, projectId, title, description, TicketStatus.Planning, now, now, labels ?? [], reporter, assignee);
 
         var file = Path.Combine(ticketsDir, $"{nextId}.md");
         WriteTicketFile(file, ticket);
@@ -108,7 +108,7 @@ public sealed class ProjectLoader(
         return ticket;
     }
 
-    public Ticket? UpdateTicket(string projectId, string ticketId, TicketStatus? status = null, string? title = null, string? description = null)
+    public Ticket? UpdateTicket(string projectId, string ticketId, TicketStatus? status = null, string? title = null, string? description = null, string? assignee = null, IReadOnlyList<string>? labels = null)
     {
         var file = ResolveTicketFile(projectId, ticketId);
         if (!File.Exists(file))
@@ -123,6 +123,8 @@ public sealed class ProjectLoader(
             Title = title ?? existing.Title,
             Description = description ?? existing.Description,
             Status = status ?? existing.Status,
+            Assignee = assignee ?? existing.Assignee,
+            Labels = labels ?? existing.Labels,
             UpdatedAt = DateTimeOffset.UtcNow
         };
 
@@ -170,8 +172,11 @@ public sealed class ProjectLoader(
         var status = TicketStatusExtensions.ParseStatus(frontmatter.GetValueOrDefault("status"));
         var createdAt = ParseDateTimeOffset(frontmatter.GetValueOrDefault("created_at"));
         var updatedAt = ParseDateTimeOffset(frontmatter.GetValueOrDefault("updated_at"));
+        var labels = ParseList(frontmatter.GetValueOrDefault("labels"));
+        var reporter = frontmatter.GetValueOrDefault("reporter")?.NullIfEmpty();
+        var assignee = frontmatter.GetValueOrDefault("assignee")?.NullIfEmpty();
 
-        return new Ticket(id, projectId, title, body, status, createdAt, updatedAt);
+        return new Ticket(id, projectId, title, body, status, createdAt, updatedAt, labels, reporter, assignee);
     }
 
     private static (Dictionary<string, string> frontmatter, string? body) ParseFrontmatter(string[] lines)
@@ -229,6 +234,12 @@ public sealed class ProjectLoader(
         writer.WriteLine("---");
         writer.WriteLine($"title: {ticket.Title}");
         writer.WriteLine($"status: {ticket.Status.ToFrontmatterValue()}");
+        if (ticket.Labels.Count > 0)
+            writer.WriteLine($"labels: {string.Join(", ", ticket.Labels)}");
+        if (!string.IsNullOrEmpty(ticket.Reporter))
+            writer.WriteLine($"reporter: {ticket.Reporter}");
+        if (!string.IsNullOrEmpty(ticket.Assignee))
+            writer.WriteLine($"assignee: {ticket.Assignee}");
         writer.WriteLine($"created_at: {ticket.CreatedAt:O}");
         writer.WriteLine($"updated_at: {ticket.UpdatedAt:O}");
         writer.WriteLine("---");
@@ -237,6 +248,16 @@ public sealed class ProjectLoader(
             writer.WriteLine();
             writer.WriteLine(ticket.Description);
         }
+    }
+
+    private static IReadOnlyList<string> ParseList(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return [];
+
+        return value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(s => s.Length > 0)
+            .ToList();
     }
 
     private static DateTimeOffset ParseDateTimeOffset(string? value) =>

--- a/SharpClaw/Models/Ticket.cs
+++ b/SharpClaw/Models/Ticket.cs
@@ -7,5 +7,11 @@ public sealed record Ticket(
     string? Description,
     TicketStatus Status,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt
-);
+    DateTimeOffset UpdatedAt,
+    IReadOnlyList<string> Labels = default!,
+    string? Reporter = null,
+    string? Assignee = null
+)
+{
+    public IReadOnlyList<string> Labels { get; init; } = Labels ?? [];
+}


### PR DESCRIPTION
## What

Extends the projects/tickets system with multi-label support and user roles (reporter/assignee), as specified in ticket #008.

## Backend Changes

- **Ticket model**: Added `Labels` (IReadOnlyList<string>), `Reporter` (string?), `Assignee` (string?)
- **Frontmatter**: Labels stored as comma-separated values; reporter/assignee as simple string fields
- **CreateTicket/UpdateTicket**: Accept new fields as optional parameters
- **All ticket API responses**: Include labels, reporter, assignee
- **`GET /api/users`**: New endpoint returning all agents from the registry + configured human users — powers assignment dropdowns

## Frontend Changes

- **Ticket cards**: Show assignee chip alongside the project chip
- **Edit dialog**: Reporter shown read-only; assignee editable via dropdown populated from `/api/users`
- **Create dialog**: Includes optional assignee dropdown
- **Types**: `TicketSummary` and `User` interfaces updated

## Testing

- `dotnet build` ✅
- `npm run build` (tsc + vite) ✅
- Backwards compatible — existing tickets without the new fields load fine (defaults to empty labels, null reporter/assignee)