### PR TITLE
Fix blank Projects page due to unhandled API errors

### DIFF
--- a/SharpClaw.Web/src/api/projects.ts
+++ b/SharpClaw.Web/src/api/projects.ts
@@ -29,8 +29,10 @@ export interface User {
 
 export const getProjects = () => apiFetch<ProjectSummary[]>('/projects');
 
-export const getProjectTickets = (projectId: string) =>
-    apiFetch<TicketSummary[]>(`/projects/${projectId}/tickets`);
+export const getProjectTickets = async (projectId: string): Promise<TicketSummary[]> => {
+    const tickets = await apiFetch<TicketSummary[]>(`/projects/${projectId}/tickets`);
+    return tickets.map(t => ({ ...t, labels: t.labels ?? [], reporter: t.reporter ?? null, assignee: t.assignee ?? null }));
+};
 
 export const getUsers = () => apiFetch<User[]>('/users');
 

--- a/SharpClaw.Web/src/pages/ProjectsPage.tsx
+++ b/SharpClaw.Web/src/pages/ProjectsPage.tsx
@@ -66,7 +66,7 @@ export default function ProjectsPage() {
             );
             setTickets(allTickets.flat());
         });
-        getUsers().then(setUsers);
+        getUsers().then(setUsers).catch(() => setUsers([]));
     }, []);
 
     const handleDragStart = useCallback((e: DragEvent, ticketId: string) => {


### PR DESCRIPTION
## Problem

The Projects page goes blank because:
1. `getUsers()` calls `/api/users` which returns HTML (SPA fallback) if the backend hasn't been restarted — JSON parse fails, unhandled promise rejection crashes the React component
2. `ticket.labels.includes()` throws when `labels` is `undefined` (backend returns tickets without the new field until restarted)

## Fix

- **API normalizer**: `getProjectTickets` now defaults `labels`, `reporter`, `assignee` to safe values at the fetch boundary
- **Error handling**: `getUsers()` catches failures and falls back to empty array

This makes the frontend resilient to partial backend rollouts.