### PR TITLE
Add project/label management UI and fix labels

### DIFF
--- a/SharpClaw.Web/src/api/projects.ts
+++ b/SharpClaw.Web/src/api/projects.ts
@@ -29,12 +29,29 @@ export interface User {
 
 export const getProjects = () => apiFetch<ProjectSummary[]>('/projects');
 
+export const createProject = (title: string, description?: string) =>
+    apiFetch<{ id: string; title: string; description: string | null; createdAt: string }>('/projects', {
+        method: 'POST',
+        body: JSON.stringify({ title, description }),
+    });
+
+export const deleteProject = (projectId: string) =>
+    apiFetch<void>(`/projects/${projectId}`, { method: 'DELETE' });
+
 export const getProjectTickets = async (projectId: string): Promise<TicketSummary[]> => {
     const tickets = await apiFetch<TicketSummary[]>(`/projects/${projectId}/tickets`);
     return tickets.map(t => ({ ...t, labels: t.labels ?? [], reporter: t.reporter ?? null, assignee: t.assignee ?? null }));
 };
 
 export const getUsers = () => apiFetch<User[]>('/users');
+
+export const getLabels = () => apiFetch<string[]>('/labels');
+
+export const addLabel = (name: string) =>
+    apiFetch<string[]>('/labels', { method: 'POST', body: JSON.stringify({ name }) });
+
+export const removeLabel = (name: string) =>
+    apiFetch<void>(`/labels/${encodeURIComponent(name)}`, { method: 'DELETE' });
 
 export const createTicket = (projectId: string, data: { title: string; description?: string; reporter?: string; assignee?: string; labels?: string[] }) =>
     apiFetch<TicketSummary>(`/projects/${projectId}/tickets`, {

--- a/SharpClaw.Web/src/pages/ProjectsPage.tsx
+++ b/SharpClaw.Web/src/pages/ProjectsPage.tsx
@@ -15,6 +15,7 @@ import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
 import AddIcon from '@mui/icons-material/Add';
 import MenuItem from '@mui/material/MenuItem';
+import Autocomplete from '@mui/material/Autocomplete';
 import Editor from '@monaco-editor/react';
 import { getProjects, getProjectTickets, getUsers, updateTicketStatus, updateTicket, createTicket, improveTicket } from '../api/projects';
 import type { ProjectSummary, TicketSummary, User } from '../api/projects';
@@ -49,6 +50,7 @@ export default function ProjectsPage() {
     const [editTitle, setEditTitle] = useState('');
     const [editDescription, setEditDescription] = useState('');
     const [editAssignee, setEditAssignee] = useState('');
+    const [editLabels, setEditLabels] = useState<string[]>([]);
     const [saving, setSaving] = useState(false);
     const [improving, setImproving] = useState(false);
     const [creatingTicket, setCreatingTicket] = useState(false);
@@ -56,6 +58,7 @@ export default function ProjectsPage() {
     const [newTicketDescription, setNewTicketDescription] = useState('');
     const [newTicketProjectId, setNewTicketProjectId] = useState('');
     const [newTicketAssignee, setNewTicketAssignee] = useState('');
+    const [newTicketLabels, setNewTicketLabels] = useState<string[]>([]);
     const [savingNew, setSavingNew] = useState(false);
 
     useEffect(() => {
@@ -117,6 +120,7 @@ export default function ProjectsPage() {
         setEditTitle(ticket.title);
         setEditDescription(ticket.description ?? '');
         setEditAssignee(ticket.assignee ?? '');
+        setEditLabels(ticket.labels ?? []);
     }, []);
 
     const handleEditorClose = useCallback(() => {
@@ -127,10 +131,12 @@ export default function ProjectsPage() {
         if (!editingTicket) return;
         setSaving(true);
         try {
-            const data: { title?: string; description?: string; assignee?: string } = {};
+            const data: { title?: string; description?: string; assignee?: string; labels?: string[] } = {};
             if (editTitle !== editingTicket.title) data.title = editTitle;
             if (editDescription !== (editingTicket.description ?? '')) data.description = editDescription;
             if (editAssignee !== (editingTicket.assignee ?? '')) data.assignee = editAssignee || undefined;
+            const existingLabels = editingTicket.labels ?? [];
+            if (JSON.stringify(editLabels.slice().sort()) !== JSON.stringify(existingLabels.slice().sort())) data.labels = editLabels;
 
             if (Object.keys(data).length > 0) {
                 const updated = await updateTicket(editingTicket.projectId, editingTicket.id, data);
@@ -140,7 +146,7 @@ export default function ProjectsPage() {
         } finally {
             setSaving(false);
         }
-    }, [editingTicket, editTitle, editDescription, editAssignee]);
+    }, [editingTicket, editTitle, editDescription, editAssignee, editLabels]);
 
     const handleImprove = useCallback(async () => {
         if (!editingTicket) return;
@@ -158,6 +164,7 @@ export default function ProjectsPage() {
         setNewTicketDescription('');
         setNewTicketProjectId(selectedProjectId ?? projects[0]?.id ?? '');
         setNewTicketAssignee('');
+        setNewTicketLabels([]);
         setCreatingTicket(true);
     }, [selectedProjectId, projects]);
 
@@ -169,13 +176,14 @@ export default function ProjectsPage() {
                 title: newTicketTitle.trim(),
                 description: newTicketDescription.trim() || undefined,
                 assignee: newTicketAssignee || undefined,
+                labels: newTicketLabels.length > 0 ? newTicketLabels : undefined,
             });
             setTickets(prev => [...prev, ticket]);
             setCreatingTicket(false);
         } finally {
             setSavingNew(false);
         }
-    }, [newTicketProjectId, newTicketTitle, newTicketDescription, newTicketAssignee]);
+    }, [newTicketProjectId, newTicketTitle, newTicketDescription, newTicketAssignee, newTicketLabels]);
 
     const filteredTickets = tickets.filter(t => {
         if (selectedProjectId && t.projectId !== selectedProjectId && !t.labels.includes(selectedProjectId))
@@ -389,6 +397,16 @@ export default function ProjectsPage() {
                                 <MenuItem key={u.id} value={u.id}>{u.name}</MenuItem>
                             ))}
                         </TextField>
+                        <Autocomplete
+                            multiple
+                            size="small"
+                            options={projects.map(p => p.id)}
+                            getOptionLabel={(id) => projects.find(p => p.id === id)?.title ?? id}
+                            value={editLabels}
+                            onChange={(_, val) => setEditLabels(val)}
+                            renderInput={(params) => <TextField {...params} label="Labels" size="small" />}
+                            sx={{ minWidth: 200 }}
+                        />
                     </Stack>
                 </DialogTitle>
                 <DialogContent sx={{ p: 0, height: 450 }}>
@@ -453,6 +471,16 @@ export default function ProjectsPage() {
                             <MenuItem key={u.id} value={u.id}>{u.name}</MenuItem>
                         ))}
                     </TextField>
+                    <Autocomplete
+                        multiple
+                        size="small"
+                        options={projects.map(p => p.id)}
+                        getOptionLabel={(id) => projects.find(p => p.id === id)?.title ?? id}
+                        value={newTicketLabels}
+                        onChange={(_, val) => setNewTicketLabels(val)}
+                        renderInput={(params) => <TextField {...params} label="Labels" size="small" />}
+                        fullWidth
+                    />
                     <Box sx={{ height: 300 }}>
                         <Editor
                             height="100%"

--- a/SharpClaw.Web/src/pages/ProjectsPage.tsx
+++ b/SharpClaw.Web/src/pages/ProjectsPage.tsx
@@ -14,10 +14,16 @@ import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
 import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SettingsIcon from '@mui/icons-material/Settings';
 import MenuItem from '@mui/material/MenuItem';
 import Autocomplete from '@mui/material/Autocomplete';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import Editor from '@monaco-editor/react';
-import { getProjects, getProjectTickets, getUsers, updateTicketStatus, updateTicket, createTicket, improveTicket } from '../api/projects';
+import { getProjects, getProjectTickets, getUsers, getLabels, addLabel, removeLabel, createProject, deleteProject, updateTicketStatus, updateTicket, createTicket, improveTicket } from '../api/projects';
 import type { ProjectSummary, TicketSummary, User } from '../api/projects';
 
 const STATUSES = [
@@ -60,6 +66,12 @@ export default function ProjectsPage() {
     const [newTicketAssignee, setNewTicketAssignee] = useState('');
     const [newTicketLabels, setNewTicketLabels] = useState<string[]>([]);
     const [savingNew, setSavingNew] = useState(false);
+    const [labels, setLabels] = useState<string[]>([]);
+    const [managingProjects, setManagingProjects] = useState(false);
+    const [newProjectTitle, setNewProjectTitle] = useState('');
+    const [newProjectDescription, setNewProjectDescription] = useState('');
+    const [managingLabels, setManagingLabels] = useState(false);
+    const [newLabelName, setNewLabelName] = useState('');
 
     useEffect(() => {
         getProjects().then(async (projs) => {
@@ -70,6 +82,7 @@ export default function ProjectsPage() {
             setTickets(allTickets.flat());
         });
         getUsers().then(setUsers).catch(() => setUsers([]));
+        getLabels().then(setLabels).catch(() => setLabels([]));
     }, []);
 
     const handleDragStart = useCallback((e: DragEvent, ticketId: string) => {
@@ -186,7 +199,7 @@ export default function ProjectsPage() {
     }, [newTicketProjectId, newTicketTitle, newTicketDescription, newTicketAssignee, newTicketLabels]);
 
     const filteredTickets = tickets.filter(t => {
-        if (selectedProjectId && t.projectId !== selectedProjectId && !t.labels.includes(selectedProjectId))
+        if (selectedProjectId && t.projectId !== selectedProjectId)
             return false;
         if (selectedAssignee && t.assignee !== selectedAssignee)
             return false;
@@ -202,6 +215,12 @@ export default function ProjectsPage() {
                 <Typography variant="h4">Projects</Typography>
                 <IconButton color="primary" onClick={handleOpenCreateTicket} title="New ticket" size="small">
                     <AddIcon />
+                </IconButton>
+                <IconButton color="default" onClick={() => setManagingProjects(true)} title="Manage projects" size="small">
+                    <SettingsIcon />
+                </IconButton>
+                <IconButton color="default" onClick={() => setManagingLabels(true)} title="Manage labels" size="small">
+                    <SettingsIcon fontSize="small" />
                 </IconButton>
             </Stack>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
@@ -333,17 +352,16 @@ export default function ProjectsPage() {
                                                     fontSize: '0.7rem',
                                                 }}
                                             />
-                                            {ticket.labels.filter(l => l !== ticket.projectId).map((label) => (
+                                            {ticket.labels.map((label) => (
                                                 <Chip
                                                     key={label}
-                                                    label={projects.find(p => p.id === label)?.title ?? label}
+                                                    label={label}
                                                     size="small"
+                                                    variant="outlined"
                                                     sx={{
-                                                        bgcolor: getProjectColour(label, projects),
-                                                        color: '#fff',
-                                                        fontWeight: 500,
                                                         fontSize: '0.7rem',
-                                                        opacity: 0.75,
+                                                        borderColor: '#7b1fa2',
+                                                        color: '#7b1fa2',
                                                     }}
                                                 />
                                             ))}
@@ -400,8 +418,8 @@ export default function ProjectsPage() {
                         <Autocomplete
                             multiple
                             size="small"
-                            options={projects.map(p => p.id)}
-                            getOptionLabel={(id) => projects.find(p => p.id === id)?.title ?? id}
+                            freeSolo
+                            options={labels}
                             value={editLabels}
                             onChange={(_, val) => setEditLabels(val)}
                             renderInput={(params) => <TextField {...params} label="Labels" size="small" />}
@@ -474,8 +492,8 @@ export default function ProjectsPage() {
                     <Autocomplete
                         multiple
                         size="small"
-                        options={projects.map(p => p.id)}
-                        getOptionLabel={(id) => projects.find(p => p.id === id)?.title ?? id}
+                        freeSolo
+                        options={labels}
                         value={newTicketLabels}
                         onChange={(_, val) => setNewTicketLabels(val)}
                         renderInput={(params) => <TextField {...params} label="Labels" size="small" />}
@@ -501,6 +519,129 @@ export default function ProjectsPage() {
                     >
                         {savingNew ? 'Creating...' : 'Create'}
                     </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* Manage Projects Dialog */}
+            <Dialog open={managingProjects} onClose={() => setManagingProjects(false)} maxWidth="sm" fullWidth>
+                <DialogTitle>Manage Projects</DialogTitle>
+                <DialogContent>
+                    <Stack direction="row" spacing={1} sx={{ mb: 2, mt: 1 }}>
+                        <TextField
+                            label="New project title"
+                            value={newProjectTitle}
+                            onChange={(e) => setNewProjectTitle(e.target.value)}
+                            size="small"
+                            sx={{ flex: 1 }}
+                        />
+                        <TextField
+                            label="Description (optional)"
+                            value={newProjectDescription}
+                            onChange={(e) => setNewProjectDescription(e.target.value)}
+                            size="small"
+                            sx={{ flex: 1 }}
+                        />
+                        <Button
+                            variant="contained"
+                            size="small"
+                            disabled={!newProjectTitle.trim()}
+                            onClick={async () => {
+                                await createProject(newProjectTitle.trim(), newProjectDescription.trim() || undefined);
+                                const projs = await getProjects();
+                                setProjects(projs);
+                                setNewProjectTitle('');
+                                setNewProjectDescription('');
+                            }}
+                        >
+                            Add
+                        </Button>
+                    </Stack>
+                    <List dense>
+                        {projects.map((p) => (
+                            <ListItem key={p.id}>
+                                <ListItemText primary={p.title} secondary={`${p.ticketCount} tickets`} />
+                                <ListItemSecondaryAction>
+                                    <IconButton
+                                        edge="end"
+                                        size="small"
+                                        disabled={p.ticketCount > 0}
+                                        title={p.ticketCount > 0 ? 'Cannot delete project with tickets' : 'Delete project'}
+                                        onClick={async () => {
+                                            await deleteProject(p.id);
+                                            setProjects(prev => prev.filter(x => x.id !== p.id));
+                                            setTickets(prev => prev.filter(t => t.projectId !== p.id));
+                                        }}
+                                    >
+                                        <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                </ListItemSecondaryAction>
+                            </ListItem>
+                        ))}
+                    </List>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setManagingProjects(false)}>Close</Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* Manage Labels Dialog */}
+            <Dialog open={managingLabels} onClose={() => setManagingLabels(false)} maxWidth="sm" fullWidth>
+                <DialogTitle>Manage Labels</DialogTitle>
+                <DialogContent>
+                    <Stack direction="row" spacing={1} sx={{ mb: 2, mt: 1 }}>
+                        <TextField
+                            label="New label"
+                            value={newLabelName}
+                            onChange={(e) => setNewLabelName(e.target.value)}
+                            size="small"
+                            sx={{ flex: 1 }}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' && newLabelName.trim()) {
+                                    addLabel(newLabelName.trim()).then(setLabels);
+                                    setNewLabelName('');
+                                }
+                            }}
+                        />
+                        <Button
+                            variant="contained"
+                            size="small"
+                            disabled={!newLabelName.trim()}
+                            onClick={async () => {
+                                const updated = await addLabel(newLabelName.trim());
+                                setLabels(updated);
+                                setNewLabelName('');
+                            }}
+                        >
+                            Add
+                        </Button>
+                    </Stack>
+                    <List dense>
+                        {labels.map((label) => (
+                            <ListItem key={label}>
+                                <ListItemText primary={label} />
+                                <ListItemSecondaryAction>
+                                    <IconButton
+                                        edge="end"
+                                        size="small"
+                                        onClick={async () => {
+                                            await removeLabel(label);
+                                            setLabels(prev => prev.filter(l => l !== label));
+                                        }}
+                                    >
+                                        <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                </ListItemSecondaryAction>
+                            </ListItem>
+                        ))}
+                        {labels.length === 0 && (
+                            <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+                                No labels yet. Add one above.
+                            </Typography>
+                        )}
+                    </List>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setManagingLabels(false)}>Close</Button>
                 </DialogActions>
             </Dialog>
         </Box>

--- a/SharpClaw/Api/ProjectEndpoints.cs
+++ b/SharpClaw/Api/ProjectEndpoints.cs
@@ -74,6 +74,37 @@ internal static class ProjectEndpoints
             }
         });
 
+        group.MapDelete("/{projectId}", (string projectId, ProjectLoader loader) =>
+        {
+            try
+            {
+                loader.DeleteProject(projectId);
+                return Results.NoContent();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.NotFound(ex.Message);
+            }
+        });
+
+        // Labels
+        app.MapGet("/api/labels", (ProjectLoader loader) => loader.GetLabels()).WithTags("Labels");
+
+        app.MapPost("/api/labels", (CreateLabelRequest req, ProjectLoader loader) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.Name))
+                return Results.BadRequest("Name is required.");
+
+            var labels = loader.AddLabel(req.Name.Trim());
+            return Results.Ok(labels);
+        }).WithTags("Labels");
+
+        app.MapDelete("/api/labels/{name}", (string name, ProjectLoader loader) =>
+        {
+            loader.RemoveLabel(name);
+            return Results.NoContent();
+        }).WithTags("Labels");
+
         // Tickets
         group.MapGet("/{projectId}/tickets", (string projectId, string? status, ProjectLoader loader) =>
         {
@@ -208,6 +239,7 @@ internal static class ProjectEndpoints
     }
 
     private sealed record CreateProjectRequest(string Title, string? Description);
+    private sealed record CreateLabelRequest(string Name);
     private sealed record CreateTicketRequest(string Title, string? Description, string? Reporter, string? Assignee, string[]? Labels);
     private sealed record UpdateTicketRequest(string? Title, string? Description, string? Status, string? Assignee, string[]? Labels);
 }

--- a/SharpClaw/Loading/ProjectLoader.cs
+++ b/SharpClaw/Loading/ProjectLoader.cs
@@ -62,6 +62,52 @@ public sealed class ProjectLoader(
         return project;
     }
 
+    public void DeleteProject(string projectId)
+    {
+        var projectDir = Path.Combine(ProjectsDir, projectId);
+        if (!Directory.Exists(projectDir))
+            throw new InvalidOperationException($"Project '{projectId}' not found.");
+
+        Directory.Delete(projectDir, recursive: true);
+        logger.LogInformation("Deleted project: {ProjectId}", projectId);
+    }
+
+    public IReadOnlyList<string> GetLabels()
+    {
+        var labelsFile = Path.Combine(ProjectsDir, "labels.json");
+        if (!File.Exists(labelsFile))
+            return [];
+
+        var json = File.ReadAllText(labelsFile);
+        return System.Text.Json.JsonSerializer.Deserialize<List<string>>(json) ?? [];
+    }
+
+    public IReadOnlyList<string> AddLabel(string name)
+    {
+        var labels = GetLabels().ToList();
+        if (!labels.Contains(name, StringComparer.OrdinalIgnoreCase))
+        {
+            labels.Add(name);
+            labels.Sort(StringComparer.OrdinalIgnoreCase);
+            WriteLabelsFile(labels);
+        }
+        return labels;
+    }
+
+    public void RemoveLabel(string name)
+    {
+        var labels = GetLabels().ToList();
+        labels.RemoveAll(l => l.Equals(name, StringComparison.OrdinalIgnoreCase));
+        WriteLabelsFile(labels);
+    }
+
+    private void WriteLabelsFile(List<string> labels)
+    {
+        var labelsFile = Path.Combine(ProjectsDir, "labels.json");
+        Directory.CreateDirectory(ProjectsDir);
+        File.WriteAllText(labelsFile, System.Text.Json.JsonSerializer.Serialize(labels, new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+    }
+
     public IReadOnlyList<Ticket> GetTickets(string projectId, TicketStatus? statusFilter = null)
     {
         var ticketsDir = Path.Combine(ProjectsDir, projectId, "tickets");


### PR DESCRIPTION
Fixes the labels system to be independent from projects and adds management UIs.

**Issues addressed:**
1. Labels no longer show project names (SharpClaw, Pension) — they're independent entities
2. Added project management (create/delete) via settings dialog
3. Added label management (create/delete) via settings dialog

**Backend changes:**
- `GET /api/labels` — returns all labels from `labels.json`
- `POST /api/labels` — add a new label
- `DELETE /api/labels/{name}` — remove a label
- `DELETE /api/projects/{id}` — delete a project (only if empty)
- `ProjectLoader` gains `DeleteProject`, `GetLabels`, `AddLabel`, `RemoveLabel` methods

**Frontend changes:**
- Manage Projects dialog: create new projects, delete empty ones
- Manage Labels dialog: create/delete labels
- Labels autocomplete (edit + create ticket) uses actual labels with freeSolo
- Label chips on kanban cards use distinct purple outline styling
- Project filter simplified (no longer cross-checks labels)