### PR TITLE
Add ticket move between projects and soft-delete

### DIFF
--- a/SharpClaw.Web/src/api/projects.ts
+++ b/SharpClaw.Web/src/api/projects.ts
@@ -72,3 +72,12 @@ export const improveTicket = (projectId: string, ticketId: string) =>
     apiFetch<{ description: string }>(`/projects/${projectId}/tickets/${ticketId}/improve`, {
         method: 'POST',
     });
+
+export const moveTicket = (projectId: string, ticketId: string, targetProjectId: string) =>
+    apiFetch<TicketSummary>(`/projects/${projectId}/tickets/${ticketId}/move`, {
+        method: 'POST',
+        body: JSON.stringify({ targetProjectId }),
+    });
+
+export const deleteTicket = (projectId: string, ticketId: string) =>
+    apiFetch<void>(`/projects/${projectId}/tickets/${ticketId}`, { method: 'DELETE' });

--- a/SharpClaw.Web/src/pages/ProjectsPage.tsx
+++ b/SharpClaw.Web/src/pages/ProjectsPage.tsx
@@ -23,7 +23,7 @@ import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import Editor from '@monaco-editor/react';
-import { getProjects, getProjectTickets, getUsers, getLabels, addLabel, removeLabel, createProject, deleteProject, updateTicketStatus, updateTicket, createTicket, improveTicket } from '../api/projects';
+import { getProjects, getProjectTickets, getUsers, getLabels, addLabel, removeLabel, createProject, deleteProject, updateTicketStatus, updateTicket, createTicket, improveTicket, moveTicket, deleteTicket } from '../api/projects';
 import type { ProjectSummary, TicketSummary, User } from '../api/projects';
 
 const STATUSES = [
@@ -57,8 +57,10 @@ export default function ProjectsPage() {
     const [editDescription, setEditDescription] = useState('');
     const [editAssignee, setEditAssignee] = useState('');
     const [editLabels, setEditLabels] = useState<string[]>([]);
+    const [editProjectId, setEditProjectId] = useState('');
     const [saving, setSaving] = useState(false);
     const [improving, setImproving] = useState(false);
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
     const [creatingTicket, setCreatingTicket] = useState(false);
     const [newTicketTitle, setNewTicketTitle] = useState('');
     const [newTicketDescription, setNewTicketDescription] = useState('');
@@ -134,6 +136,7 @@ export default function ProjectsPage() {
         setEditDescription(ticket.description ?? '');
         setEditAssignee(ticket.assignee ?? '');
         setEditLabels(ticket.labels ?? []);
+        setEditProjectId(ticket.projectId);
     }, []);
 
     const handleEditorClose = useCallback(() => {
@@ -144,22 +147,39 @@ export default function ProjectsPage() {
         if (!editingTicket) return;
         setSaving(true);
         try {
-            const data: { title?: string; description?: string; assignee?: string; labels?: string[] } = {};
-            if (editTitle !== editingTicket.title) data.title = editTitle;
-            if (editDescription !== (editingTicket.description ?? '')) data.description = editDescription;
-            if (editAssignee !== (editingTicket.assignee ?? '')) data.assignee = editAssignee || undefined;
-            const existingLabels = editingTicket.labels ?? [];
-            if (JSON.stringify(editLabels.slice().sort()) !== JSON.stringify(existingLabels.slice().sort())) data.labels = editLabels;
+            // Handle project move first
+            if (editProjectId !== editingTicket.projectId) {
+                const moved = await moveTicket(editingTicket.projectId, editingTicket.id, editProjectId);
+                setTickets(prev => prev.map(t => t.id === editingTicket.id ? moved : t));
+                // Update remaining fields on the moved ticket
+                const data: { title?: string; description?: string; assignee?: string; labels?: string[] } = {};
+                if (editTitle !== editingTicket.title) data.title = editTitle;
+                if (editDescription !== (editingTicket.description ?? '')) data.description = editDescription;
+                if (editAssignee !== (editingTicket.assignee ?? '')) data.assignee = editAssignee || undefined;
+                const existingLabels = editingTicket.labels ?? [];
+                if (JSON.stringify(editLabels.slice().sort()) !== JSON.stringify(existingLabels.slice().sort())) data.labels = editLabels;
+                if (Object.keys(data).length > 0) {
+                    const updated = await updateTicket(editProjectId, editingTicket.id, data);
+                    setTickets(prev => prev.map(t => t.id === updated.id ? updated : t));
+                }
+            } else {
+                const data: { title?: string; description?: string; assignee?: string; labels?: string[] } = {};
+                if (editTitle !== editingTicket.title) data.title = editTitle;
+                if (editDescription !== (editingTicket.description ?? '')) data.description = editDescription;
+                if (editAssignee !== (editingTicket.assignee ?? '')) data.assignee = editAssignee || undefined;
+                const existingLabels = editingTicket.labels ?? [];
+                if (JSON.stringify(editLabels.slice().sort()) !== JSON.stringify(existingLabels.slice().sort())) data.labels = editLabels;
 
-            if (Object.keys(data).length > 0) {
-                const updated = await updateTicket(editingTicket.projectId, editingTicket.id, data);
-                setTickets(prev => prev.map(t => t.id === updated.id ? updated : t));
+                if (Object.keys(data).length > 0) {
+                    const updated = await updateTicket(editingTicket.projectId, editingTicket.id, data);
+                    setTickets(prev => prev.map(t => t.id === updated.id ? updated : t));
+                }
             }
             setEditingTicket(null);
         } finally {
             setSaving(false);
         }
-    }, [editingTicket, editTitle, editDescription, editAssignee, editLabels]);
+    }, [editingTicket, editTitle, editDescription, editAssignee, editLabels, editProjectId]);
 
     const handleImprove = useCallback(async () => {
         if (!editingTicket) return;
@@ -169,6 +189,19 @@ export default function ProjectsPage() {
             setEditDescription(result.description);
         } finally {
             setImproving(false);
+        }
+    }, [editingTicket]);
+
+    const handleDeleteTicket = useCallback(async () => {
+        if (!editingTicket) return;
+        setSaving(true);
+        try {
+            await deleteTicket(editingTicket.projectId, editingTicket.id);
+            setTickets(prev => prev.filter(t => t.id !== editingTicket.id));
+            setEditingTicket(null);
+            setConfirmingDelete(false);
+        } finally {
+            setSaving(false);
         }
     }, [editingTicket]);
 
@@ -404,6 +437,18 @@ export default function ProjectsPage() {
                         )}
                         <TextField
                             select
+                            label="Project"
+                            value={editProjectId}
+                            onChange={(e) => setEditProjectId(e.target.value)}
+                            size="small"
+                            sx={{ minWidth: 150 }}
+                        >
+                            {projects.map((p) => (
+                                <MenuItem key={p.id} value={p.id}>{p.title}</MenuItem>
+                            ))}
+                        </TextField>
+                        <TextField
+                            select
                             label="Assignee"
                             value={editAssignee}
                             onChange={(e) => setEditAssignee(e.target.value)}
@@ -441,10 +486,28 @@ export default function ProjectsPage() {
                     <Button onClick={handleImprove} disabled={improving || saving} color="secondary">
                         {improving ? 'Improving...' : 'Improve'}
                     </Button>
+                    <Button onClick={() => setConfirmingDelete(true)} disabled={saving || improving} color="error">
+                        Delete
+                    </Button>
                     <Box sx={{ flex: 1 }} />
                     <Button onClick={handleEditorClose}>Cancel</Button>
                     <Button variant="contained" onClick={handleEditorSave} disabled={saving || improving}>
                         {saving ? 'Saving...' : 'Save'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <Dialog open={confirmingDelete} onClose={() => setConfirmingDelete(false)} maxWidth="xs">
+                <DialogTitle>Delete Ticket?</DialogTitle>
+                <DialogContent>
+                    <Typography>
+                        Are you sure you want to delete ticket <strong>{editingTicket?.id}</strong>: &quot;{editingTicket?.title}&quot;? This action cannot be undone from the UI.
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setConfirmingDelete(false)}>Cancel</Button>
+                    <Button onClick={handleDeleteTicket} color="error" variant="contained" disabled={saving}>
+                        {saving ? 'Deleting...' : 'Delete'}
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/SharpClaw/Api/ProjectEndpoints.cs
+++ b/SharpClaw/Api/ProjectEndpoints.cs
@@ -196,6 +196,46 @@ internal static class ProjectEndpoints
             });
         });
 
+        group.MapPost("/{projectId}/tickets/{ticketId}/move", (string projectId, string ticketId, MoveTicketRequest req, ProjectLoader loader) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.TargetProjectId))
+                return Results.BadRequest("targetProjectId is required.");
+
+            if (req.TargetProjectId == projectId)
+                return Results.BadRequest("Ticket is already in that project.");
+
+            try
+            {
+                var moved = loader.MoveTicket(projectId, ticketId, req.TargetProjectId);
+                if (moved is null) return Results.NotFound();
+
+                return Results.Ok(new
+                {
+                    moved.Id,
+                    moved.ProjectId,
+                    moved.Title,
+                    moved.Description,
+                    Status = moved.Status.ToFrontmatterValue(),
+                    moved.Labels,
+                    moved.Reporter,
+                    moved.Assignee,
+                    moved.CreatedAt,
+                    moved.UpdatedAt,
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        group.MapDelete("/{projectId}/tickets/{ticketId}", (string projectId, string ticketId, ProjectLoader loader) =>
+        {
+            var deleted = loader.DeleteTicket(projectId, ticketId);
+            if (!deleted) return Results.NotFound();
+            return Results.NoContent();
+        });
+
         group.MapPost("/{projectId}/tickets/{ticketId}/improve", async (
             string projectId,
             string ticketId,
@@ -242,4 +282,5 @@ internal static class ProjectEndpoints
     private sealed record CreateLabelRequest(string Name);
     private sealed record CreateTicketRequest(string Title, string? Description, string? Reporter, string? Assignee, string[]? Labels);
     private sealed record UpdateTicketRequest(string? Title, string? Description, string? Status, string? Assignee, string[]? Labels);
+    private sealed record MoveTicketRequest(string TargetProjectId);
 }

--- a/SharpClaw/Loading/ProjectLoader.cs
+++ b/SharpClaw/Loading/ProjectLoader.cs
@@ -180,6 +180,50 @@ public sealed class ProjectLoader(
         return updated;
     }
 
+    public Ticket? MoveTicket(string projectId, string ticketId, string newProjectId)
+    {
+        var sourceFile = ResolveTicketFile(projectId, ticketId);
+        if (!File.Exists(sourceFile))
+            return null;
+
+        var targetTicketsDir = Path.Combine(ProjectsDir, newProjectId, "tickets");
+        if (!Directory.Exists(targetTicketsDir))
+            throw new InvalidOperationException($"Target project '{newProjectId}' not found.");
+
+        var existing = ParseTicket(projectId, sourceFile);
+        if (existing is null)
+            return null;
+
+        var moved = existing with
+        {
+            ProjectId = newProjectId,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var targetFile = Path.Combine(targetTicketsDir, $"{ticketId}.md");
+        WriteTicketFile(targetFile, moved);
+        File.Delete(sourceFile);
+
+        logger.LogInformation("Moved ticket {TicketId} from project {FromProject} to {ToProject}", ticketId, projectId, newProjectId);
+        return moved;
+    }
+
+    public bool DeleteTicket(string projectId, string ticketId)
+    {
+        var file = ResolveTicketFile(projectId, ticketId);
+        if (!File.Exists(file))
+            return false;
+
+        var deletedDir = Path.Combine(ProjectsDir, projectId, "tickets", ".deleted");
+        Directory.CreateDirectory(deletedDir);
+
+        var deletedFile = Path.Combine(deletedDir, $"{ticketId}.md");
+        File.Move(file, deletedFile, overwrite: true);
+
+        logger.LogInformation("Soft-deleted ticket {TicketId} from project {ProjectId}", ticketId, projectId);
+        return true;
+    }
+
     private string ResolveTicketFile(string projectId, string ticketId)
     {
         var ticketsDir = Path.Combine(ProjectsDir, projectId, "tickets");

--- a/SharpClaw/Tools/TicketTool.cs
+++ b/SharpClaw/Tools/TicketTool.cs
@@ -7,16 +7,17 @@ namespace SharpClaw.Tools;
 public sealed class TicketTool(ProjectLoader loader) : ITool
 {
     public string Name => "ticket";
-    public string Description => "Manage project tickets. Actions: list_tickets, create_ticket, update_ticket, get_ticket.";
+    public string Description => "Manage project tickets. Actions: list_tickets, create_ticket, update_ticket, get_ticket, move_ticket, delete_ticket.";
 
     public IReadOnlyList<ToolParameterDefinition> Parameters { get; } =
     [
-        new("action", "string", "The action to perform: list_tickets, create_ticket, update_ticket, get_ticket.", Required: true),
+        new("action", "string", "The action to perform: list_tickets, create_ticket, update_ticket, get_ticket, move_ticket, delete_ticket.", Required: true),
         new("project_id", "string", "Project ID (slug). Required for all actions.", Required: true),
-        new("ticket_id", "string", "Ticket ID (e.g. '001'). Required for get_ticket and update_ticket.", Required: false),
+        new("ticket_id", "string", "Ticket ID (e.g. '001'). Required for get_ticket, update_ticket, move_ticket, delete_ticket.", Required: false),
         new("title", "string", "Ticket title. Required for create_ticket, optional for update_ticket.", Required: false),
         new("description", "string", "Ticket description. Optional for create_ticket and update_ticket.", Required: false),
         new("status", "string", "Ticket status: idea, planning, in_progress, for_review, done. Optional for update_ticket.", Required: false),
+        new("target_project_id", "string", "Target project ID for move_ticket.", Required: false),
     ];
 
     public Task<object?> ExecuteAsync(ToolCallContext context, CancellationToken ct = default)
@@ -29,7 +30,9 @@ public sealed class TicketTool(ProjectLoader loader) : ITool
             "create_ticket" => CreateTicket(context),
             "update_ticket" => UpdateTicket(context),
             "get_ticket" => GetTicket(context),
-            _ => Task.FromResult<object?>($"Error: Unknown action '{action}'. Use: list_tickets, create_ticket, update_ticket, get_ticket.")
+            "move_ticket" => MoveTicket(context),
+            "delete_ticket" => DeleteTicket(context),
+            _ => Task.FromResult<object?>($"Error: Unknown action '{action}'. Use: list_tickets, create_ticket, update_ticket, get_ticket, move_ticket, delete_ticket.")
         };
     }
 
@@ -123,5 +126,49 @@ public sealed class TicketTool(ProjectLoader loader) : ITool
             result += $"\n\n{ticket.Description}";
 
         return Task.FromResult<object?>(result);
+    }
+
+    private Task<object?> MoveTicket(ToolCallContext context)
+    {
+        var projectId = context.GetString("project_id");
+        var ticketId = context.GetString("ticket_id");
+        var targetProjectId = context.GetString("target_project_id");
+
+        if (string.IsNullOrWhiteSpace(projectId))
+            return Task.FromResult<object?>("Error: 'project_id' is required.");
+        if (string.IsNullOrWhiteSpace(ticketId))
+            return Task.FromResult<object?>("Error: 'ticket_id' is required for move_ticket.");
+        if (string.IsNullOrWhiteSpace(targetProjectId))
+            return Task.FromResult<object?>("Error: 'target_project_id' is required for move_ticket.");
+
+        try
+        {
+            var moved = loader.MoveTicket(projectId, ticketId, targetProjectId);
+            if (moved is null)
+                return Task.FromResult<object?>($"Error: Ticket '{ticketId}' not found in project '{projectId}'.");
+
+            return Task.FromResult<object?>($"Moved ticket `{moved.Id}` from '{projectId}' to '{targetProjectId}': {moved.Title}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Task.FromResult<object?>($"Error: {ex.Message}");
+        }
+    }
+
+    private Task<object?> DeleteTicket(ToolCallContext context)
+    {
+        var projectId = context.GetString("project_id");
+        var ticketId = context.GetString("ticket_id");
+
+        if (string.IsNullOrWhiteSpace(projectId))
+            return Task.FromResult<object?>("Error: 'project_id' is required.");
+        if (string.IsNullOrWhiteSpace(ticketId))
+            return Task.FromResult<object?>("Error: 'ticket_id' is required for delete_ticket.");
+
+        var deleted = loader.DeleteTicket(projectId, ticketId);
+        if (!deleted)
+            return Task.FromResult<object?>($"Error: Ticket '{ticketId}' not found in project '{projectId}'.");
+
+        return Task.FromResult<object?>($"Deleted ticket `{ticketId}` from project '{projectId}'.");
     }
 }

--- a/docs/docs/features/projects.md
+++ b/docs/docs/features/projects.md
@@ -141,14 +141,15 @@ Manage projects from within agent conversations.
 
 Manage tickets from within agent conversations.
 
-| Parameter     | Type   | Required | Description                                           |
-| ------------- | ------ | -------- | ----------------------------------------------------- |
-| `action`      | string | Yes      | `list_tickets`, `create_ticket`, `update_ticket`, `get_ticket` |
-| `project_id`  | string | Yes      | Project ID slug                                       |
-| `ticket_id`   | string | No       | Ticket ID, e.g. `001` (required for `get_ticket`, `update_ticket`) |
-| `title`       | string | No       | Ticket title (required for `create_ticket`)           |
-| `description` | string | No       | Ticket description in markdown                        |
-| `status`      | string | No       | New status (for `update_ticket`)                      |
+| Parameter           | Type   | Required | Description                                           |
+| ------------------- | ------ | -------- | ----------------------------------------------------- |
+| `action`            | string | Yes      | `list_tickets`, `create_ticket`, `update_ticket`, `get_ticket`, `move_ticket`, `delete_ticket` |
+| `project_id`        | string | Yes      | Project ID slug                                       |
+| `ticket_id`         | string | No       | Ticket ID, e.g. `001` (required for `get_ticket`, `update_ticket`, `move_ticket`, `delete_ticket`) |
+| `title`             | string | No       | Ticket title (required for `create_ticket`)           |
+| `description`       | string | No       | Ticket description in markdown                        |
+| `status`            | string | No       | New status (for `update_ticket`)                      |
+| `target_project_id` | string | No       | Target project ID (required for `move_ticket`)        |
 
 **Actions:**
 
@@ -156,6 +157,8 @@ Manage tickets from within agent conversations.
 - **`create_ticket`** — Creates a new ticket with auto-incremented ID. Default status is `planning`.
 - **`update_ticket`** — Updates a ticket's title, description, and/or status.
 - **`get_ticket`** — Returns full ticket details including description.
+- **`move_ticket`** — Moves a ticket from one project to another. The ticket retains its ID and all metadata.
+- **`delete_ticket`** — Soft-deletes a ticket by moving it to a `.deleted/` folder within the project's tickets directory. The ticket is removed from all lists but can be recovered from disk.
 
 ### Example: Agent Workflow
 
@@ -336,6 +339,37 @@ All fields are optional — include only what you want to change.
 
 **Response** `404 Not Found` if ticket doesn't exist.
 
+### Move Ticket
+
+```http
+POST /api/projects/{projectId}/tickets/{ticketId}/move
+Content-Type: application/json
+
+{
+  "targetProjectId": "another-project"
+}
+```
+
+Moves a ticket from one project to another, preserving the ticket ID and all metadata.
+
+**Response** `200 OK` — Returns the ticket with updated `projectId`.
+
+**Errors:**
+- `400 Bad Request` — Target project ID missing, same as current, or target project not found
+- `404 Not Found` — Ticket doesn't exist
+
+### Delete Ticket
+
+```http
+DELETE /api/projects/{projectId}/tickets/{ticketId}
+```
+
+Soft-deletes a ticket by moving it to a `.deleted/` subdirectory within the project's tickets folder. The file is preserved on disk for recovery but removed from all API responses and UI views.
+
+**Response** `204 No Content` — Ticket was deleted.
+
+**Response** `404 Not Found` — Ticket doesn't exist.
+
 ### Improve Ticket (AI-powered)
 
 ```http
@@ -363,6 +397,8 @@ The **Projects** page in the web UI (`/projects`) displays a Kanban board with d
 - **Cards** show the ticket number, title, and a colour-coded project chip
 - **Drag and drop** tickets between columns to change status
 - **Click** a card to open an editor dialog with the full markdown description
+- **Move tickets** between projects using the Project dropdown in the edit dialog
+- **Delete tickets** via the Delete button in the edit dialog (with confirmation prompt)
 - **Filter** by project using the chips at the top
 - **Improve** button uses AI to enhance the ticket description
 


### PR DESCRIPTION
## Summary

Implements ticket #015 — adds two missing ticket management features:

### Move Ticket Between Projects
- **Backend**: `ProjectLoader.MoveTicket()` physically moves the .md file to the target project's tickets directory
- **API**: `POST /api/projects/{projectId}/tickets/{ticketId}/move` with `{targetProjectId}` body
- **Agent tool**: `ticket` tool gains `move_ticket` action with `target_project_id` parameter
- **Web UI**: Project dropdown selector in the ticket edit dialog

### Delete Ticket (Soft Delete)
- **Backend**: `ProjectLoader.DeleteTicket()` moves the file to a `.deleted/` subfolder within the project's tickets directory
- **API**: `DELETE /api/projects/{projectId}/tickets/{ticketId}`
- **Agent tool**: `ticket` tool gains `delete_ticket` action
- **Web UI**: Delete button in edit dialog with confirmation prompt

### Documentation
- Updated `docs/docs/features/projects.md` with new endpoints, tool parameters, and UI features

### Testing
- `dotnet build` — 0 errors
- `npm run build` (frontend) — success
- `cd docs && npm run build` — success