### PR TITLE
Add 'Todo' ticket status and kanban column

### DIFF
--- a/SharpClaw.Web/src/pages/ProjectsPage.tsx
+++ b/SharpClaw.Web/src/pages/ProjectsPage.tsx
@@ -29,6 +29,7 @@ import type { ProjectSummary, TicketSummary, User } from '../api/projects';
 const STATUSES = [
     { key: 'idea', label: 'Idea' },
     { key: 'planning', label: 'Planning' },
+    { key: 'todo', label: 'Todo' },
     { key: 'in_progress', label: 'In Progress' },
     { key: 'for_review', label: 'For Review' },
     { key: 'done', label: 'Done' },

--- a/SharpClaw/Models/TicketStatus.cs
+++ b/SharpClaw/Models/TicketStatus.cs
@@ -4,6 +4,7 @@ public enum TicketStatus
 {
     Idea,
     Planning,
+    Todo,
     InProgress,
     ForReview,
     Done
@@ -15,6 +16,7 @@ public static class TicketStatusExtensions
     {
         TicketStatus.Idea => "idea",
         TicketStatus.Planning => "planning",
+        TicketStatus.Todo => "todo",
         TicketStatus.InProgress => "in_progress",
         TicketStatus.ForReview => "for_review",
         TicketStatus.Done => "done",
@@ -25,6 +27,7 @@ public static class TicketStatusExtensions
     {
         "idea" => TicketStatus.Idea,
         "planning" => TicketStatus.Planning,
+        "todo" => TicketStatus.Todo,
         "in_progress" => TicketStatus.InProgress,
         "for_review" => TicketStatus.ForReview,
         "done" => TicketStatus.Done,

--- a/SharpClaw/Tools/TicketTool.cs
+++ b/SharpClaw/Tools/TicketTool.cs
@@ -16,7 +16,7 @@ public sealed class TicketTool(ProjectLoader loader) : ITool
         new("ticket_id", "string", "Ticket ID (e.g. '001'). Required for get_ticket, update_ticket, move_ticket, delete_ticket.", Required: false),
         new("title", "string", "Ticket title. Required for create_ticket, optional for update_ticket.", Required: false),
         new("description", "string", "Ticket description. Optional for create_ticket and update_ticket.", Required: false),
-        new("status", "string", "Ticket status: idea, planning, in_progress, for_review, done. Optional for update_ticket.", Required: false),
+        new("status", "string", "Ticket status: idea, planning, todo, in_progress, for_review, done. Optional for update_ticket.", Required: false),
         new("target_project_id", "string", "Target project ID for move_ticket.", Required: false),
     ];
 

--- a/docs/docs/features/projects.md
+++ b/docs/docs/features/projects.md
@@ -79,6 +79,7 @@ The filename (without `.md`) is the **ticket ID** — a zero-padded number like 
 | ------------- | ----------------- | ---------------------------------- |
 | Idea          | `idea`            | Captured but not yet planned       |
 | Planning      | `planning`        | Being scoped and specified         |
+| Todo          | `todo`            | Planned and ready to be picked up  |
 | In Progress   | `in_progress`     | Actively being worked on           |
 | For Review    | `for_review`      | Complete, awaiting review          |
 | Done          | `done`            | Finished                           |
@@ -393,7 +394,7 @@ Uses an LLM to rewrite and improve the ticket description, making it clearer and
 
 The **Projects** page in the web UI (`/projects`) displays a Kanban board with drag-and-drop ticket management:
 
-- **Columns** represent statuses: Idea → Planning → In Progress → For Review → Done
+- **Columns** represent statuses: Idea → Planning → Todo → In Progress → For Review → Done
 - **Cards** show the ticket number, title, and a colour-coded project chip
 - **Drag and drop** tickets between columns to change status
 - **Click** a card to open an editor dialog with the full markdown description


### PR DESCRIPTION
Adds a new `todo` status between `planning` and `in_progress` in the ticket system, with a corresponding column on the kanban board.

## Changes
- **TicketStatus.cs** — Added `Todo` enum variant
- **TicketStatusExtensions** — Added `todo` serialization/parsing
- **TicketTool.cs** — Updated status description to include `todo`
- **ProjectsPage.tsx** — Added `todo` column to kanban STATUSES array
- **docs/features/projects.md** — Updated status table and column list

## Testing
- `dotnet build` ✅
- `npm run build` (frontend) ✅
- `npm run build` (docs) ✅

Closes #017