### PR TITLE
Move semantic-memory.db to workspace directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ Thumbs.db
 *.swo
 *~
 
+# Database files
+*.db
+
 # Logs
 *.log
 logs/

--- a/SharpClaw/Memory/SemanticMemoryStore.cs
+++ b/SharpClaw/Memory/SemanticMemoryStore.cs
@@ -11,14 +11,17 @@ public sealed class SemanticMemoryStore : IDisposable
     private readonly ILogger<SemanticMemoryStore> _logger;
     private bool _disposed;
 
-    public SemanticMemoryStore(IOptions<SemanticMemoryOptions> options, ILogger<SemanticMemoryStore> logger)
+    public SemanticMemoryStore(IOptions<SemanticMemoryOptions> options, IOptions<SharpClawOptions> sharpClawOptions, ILogger<SemanticMemoryStore> logger)
     {
         _logger = logger;
         _dimension = options.Value.EmbeddingDimension;
 
+        var workspacePath = sharpClawOptions.Value.WorkspacePath;
         var dbPath = Path.IsPathRooted(options.Value.DatabasePath)
             ? options.Value.DatabasePath
-            : Path.Combine(AppContext.BaseDirectory, options.Value.DatabasePath);
+            : !string.IsNullOrEmpty(workspacePath)
+                ? Path.Combine(workspacePath, options.Value.DatabasePath)
+                : Path.Combine(AppContext.BaseDirectory, options.Value.DatabasePath);
 
         Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
 


### PR DESCRIPTION
Resolves semantic-memory.db path relative to the configured WorkspacePath instead of AppContext.BaseDirectory. This ensures the working database lives in the workspace folder (e.g. `/home/khughes/sharpclaw-workspace/data/semantic-memory.db`) and not alongside the application binaries.

## Changes
- **SemanticMemoryStore.cs** — Inject `IOptions<SharpClawOptions>`, resolve DatabasePath relative to WorkspacePath when configured
- **.gitignore** — Added `*.db` to prevent accidental database commits

## Fallback behaviour
If WorkspacePath is not configured (empty string), falls back to the previous behaviour (relative to AppContext.BaseDirectory).

## Testing
- `dotnet build` ✅