### PR TITLE
Make kanban board fill full panel width

### DIFF
--- a/SharpClaw.Web/src/pages/ProjectsPage.tsx
+++ b/SharpClaw.Web/src/pages/ProjectsPage.tsx
@@ -329,7 +329,7 @@ export default function ProjectsPage() {
                 <Typography color="text.secondary">No projects found.</Typography>
             )}
 
-            <Box sx={{ display: 'flex', gap: 2, overflowX: 'auto', pb: 2 }}>
+            <Box sx={{ display: 'flex', gap: 1, pb: 2, width: '100%' }}>
                 {STATUSES.map(({ key, label }) => (
                     <Paper
                         key={key}
@@ -338,8 +338,8 @@ export default function ProjectsPage() {
                         onDragLeave={handleDragLeave}
                         onDrop={(e) => handleDrop(e as unknown as DragEvent, key)}
                         sx={{
-                            flex: '1 1 0',
-                            minWidth: 260,
+                            flex: 1,
+                            minWidth: 0,
                             p: 1.5,
                             bgcolor: dragOverStatus === key ? 'action.hover' : 'background.default',
                             transition: 'background-color 0.15s',


### PR DESCRIPTION
The kanban board on the Projects page was constrained to ~half the panel width with horizontal scrolling required to see all 6 status columns.

**Changes:**
- Removed `overflowX: auto` from the board container so it doesn't scroll
- Set columns to `flex: 1` with `minWidth: 0` so they distribute evenly across the full width
- Reduced gap from 2 to 1 to give columns more breathing room

**Result:** All 6 columns are now visible at once, evenly spread across the full right panel.