### PR TITLE
Remove maxWidth constraint from dashboard layout

### DIFF
--- a/SharpClaw.Web/src/layouts/DashboardLayout.tsx
+++ b/SharpClaw.Web/src/layouts/DashboardLayout.tsx
@@ -23,7 +23,6 @@ export default function DashboardLayout() {
                         mx: 3,
                         pb: 5,
                         mt: { xs: 8, md: 2 },
-                        maxWidth: 1400,
                     }}
                 >
                     <Outlet />


### PR DESCRIPTION
Follow-up to PR #87. The kanban board still only took half the screen because the DashboardLayout content wrapper had a `maxWidth: 1400` constraint capping the usable width. Removing it allows the kanban columns to fill the full panel.