### PR TITLE
Token Usage Tracking

### DIFF
--- a/SharpClaw.Web/src/App.tsx
+++ b/SharpClaw.Web/src/App.tsx
@@ -14,6 +14,7 @@ import TaskListPage from './pages/TaskListPage';
 import TaskCreatePage from './pages/TaskCreatePage';
 import TaskEditorPage from './pages/TaskEditorPage';
 import ProjectsPage from './pages/ProjectsPage';
+import TokensPage from './pages/TokensPage';
 import ConfigPage from './pages/ConfigPage';
 import ExamplesPage from './pages/ExamplesPage';
 
@@ -38,6 +39,7 @@ export default function App() {
                 <Route path="/tasks/new" element={<TaskCreatePage />} />
                 <Route path="/tasks/:id" element={<TaskEditorPage />} />
                 <Route path="/projects" element={<ProjectsPage />} />
+                <Route path="/tokens" element={<TokensPage />} />
                 <Route path="/config" element={<ConfigPage />} />
                 <Route path="/examples" element={<ExamplesPage />} />
             </Route>

--- a/SharpClaw.Web/src/api/tokens.ts
+++ b/SharpClaw.Web/src/api/tokens.ts
@@ -1,0 +1,64 @@
+import { apiFetch } from './client';
+
+export interface TokenUsageSummary {
+    agentName: string;
+    provider: string;
+    model: string | null;
+    requestCount: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    avgDurationMs: number;
+}
+
+export interface TokenUsageDaily {
+    date: string;
+    requestCount: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+}
+
+export interface TokenUsageEntry {
+    id: number;
+    timestampUtc: string;
+    agentName: string;
+    provider: string;
+    model: string | null;
+    sessionId: string | null;
+    inputTokens: number | null;
+    outputTokens: number | null;
+    totalTokens: number | null;
+    durationMs: number | null;
+    toolCount: number;
+    mcpCount: number;
+    skills: string | null;
+    success: boolean;
+}
+
+export function getTokenSummary(params?: { from?: string; to?: string; agent?: string; provider?: string }): Promise<TokenUsageSummary[]> {
+    const q = new URLSearchParams();
+    if (params?.from) q.set('from', params.from);
+    if (params?.to) q.set('to', params.to);
+    if (params?.agent) q.set('agent', params.agent);
+    if (params?.provider) q.set('provider', params.provider);
+    const qs = q.toString();
+    return apiFetch(`/tokens/summary${qs ? `?${qs}` : ''}`);
+}
+
+export function getTokenDaily(params?: { from?: string; to?: string; agent?: string; provider?: string }): Promise<TokenUsageDaily[]> {
+    const q = new URLSearchParams();
+    if (params?.from) q.set('from', params.from);
+    if (params?.to) q.set('to', params.to);
+    if (params?.agent) q.set('agent', params.agent);
+    if (params?.provider) q.set('provider', params.provider);
+    const qs = q.toString();
+    return apiFetch(`/tokens/daily${qs ? `?${qs}` : ''}`);
+}
+
+export function getTokenRecent(params?: { limit?: number; agent?: string; provider?: string }): Promise<TokenUsageEntry[]> {
+    const q = new URLSearchParams();
+    if (params?.limit) q.set('limit', params.limit.toString());
+    if (params?.agent) q.set('agent', params.agent);
+    if (params?.provider) q.set('provider', params.provider);
+    const qs = q.toString();
+    return apiFetch(`/tokens/recent${qs ? `?${qs}` : ''}`);
+}

--- a/SharpClaw.Web/src/components/MenuContent.tsx
+++ b/SharpClaw.Web/src/components/MenuContent.tsx
@@ -14,6 +14,7 @@ import SchoolRoundedIcon from '@mui/icons-material/SchoolRounded';
 import WidgetsRoundedIcon from '@mui/icons-material/WidgetsRounded';
 import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
 import ViewKanbanRoundedIcon from '@mui/icons-material/ViewKanbanRounded';
+import DataUsageRoundedIcon from '@mui/icons-material/DataUsageRounded';
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 
@@ -25,6 +26,7 @@ const mainItems = [
     { text: 'Skills', icon: <SchoolRoundedIcon />, path: '/skills' },
     { text: 'Tasks', icon: <ScheduleRoundedIcon />, path: '/tasks' },
     { text: 'Projects', icon: <ViewKanbanRoundedIcon />, path: '/projects' },
+    { text: 'Tokens', icon: <DataUsageRoundedIcon />, path: '/tokens' },
     { text: 'Examples', icon: <WidgetsRoundedIcon />, path: '/examples' },
 ];
 

--- a/SharpClaw.Web/src/pages/TokensPage.tsx
+++ b/SharpClaw.Web/src/pages/TokensPage.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import { getTokenSummary, getTokenDaily, getTokenRecent } from '../api/tokens';
+import type { TokenUsageSummary, TokenUsageDaily, TokenUsageEntry } from '../api/tokens';
+
+function formatNumber(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+    return n.toString();
+}
+
+function formatDuration(ms: number | null): string {
+    if (ms === null) return '—';
+    if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+    return `${Math.round(ms)}ms`;
+}
+
+export default function TokensPage() {
+    const [summary, setSummary] = useState<TokenUsageSummary[]>([]);
+    const [daily, setDaily] = useState<TokenUsageDaily[]>([]);
+    const [recent, setRecent] = useState<TokenUsageEntry[]>([]);
+    const [filterAgent, setFilterAgent] = useState('');
+    const [filterProvider, setFilterProvider] = useState('');
+
+    const loadData = () => {
+        const params = {
+            agent: filterAgent || undefined,
+            provider: filterProvider || undefined,
+        };
+        getTokenSummary(params).then(setSummary);
+        getTokenDaily(params).then(setDaily);
+        getTokenRecent({ ...params, limit: 100 }).then(setRecent);
+    };
+
+    useEffect(() => { loadData(); }, [filterAgent, filterProvider]);
+
+    const totalInput = summary.reduce((acc, s) => acc + s.totalInputTokens, 0);
+    const totalOutput = summary.reduce((acc, s) => acc + s.totalOutputTokens, 0);
+    const totalRequests = summary.reduce((acc, s) => acc + s.requestCount, 0);
+
+    const agents = [...new Set(summary.map(s => s.agentName))];
+    const providers = [...new Set(summary.map(s => s.provider))];
+
+    // Daily chart as a simple bar visualization
+    const maxDailyTokens = Math.max(...daily.map(d => d.totalInputTokens + d.totalOutputTokens), 1);
+
+    return (
+        <Box>
+            <Typography variant="h4" sx={{ mb: 1 }}>Tokens</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                Token usage across all LLM interactions.
+            </Typography>
+
+            {/* Filters */}
+            <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
+                <TextField
+                    select
+                    label="Agent"
+                    value={filterAgent}
+                    onChange={(e) => setFilterAgent(e.target.value)}
+                    size="small"
+                    sx={{ minWidth: 150 }}
+                >
+                    <MenuItem value="">All</MenuItem>
+                    {agents.map(a => <MenuItem key={a} value={a}>{a}</MenuItem>)}
+                </TextField>
+                <TextField
+                    select
+                    label="Provider"
+                    value={filterProvider}
+                    onChange={(e) => setFilterProvider(e.target.value)}
+                    size="small"
+                    sx={{ minWidth: 150 }}
+                >
+                    <MenuItem value="">All</MenuItem>
+                    {providers.map(p => <MenuItem key={p} value={p}>{p}</MenuItem>)}
+                </TextField>
+            </Stack>
+
+            {/* Summary Cards */}
+            <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
+                <Paper variant="outlined" sx={{ p: 2, flex: 1, textAlign: 'center' }}>
+                    <Typography variant="h5" color="primary">{formatNumber(totalInput + totalOutput)}</Typography>
+                    <Typography variant="caption" color="text.secondary">Total Tokens</Typography>
+                </Paper>
+                <Paper variant="outlined" sx={{ p: 2, flex: 1, textAlign: 'center' }}>
+                    <Typography variant="h5" color="info.main">{formatNumber(totalInput)}</Typography>
+                    <Typography variant="caption" color="text.secondary">Input Tokens</Typography>
+                </Paper>
+                <Paper variant="outlined" sx={{ p: 2, flex: 1, textAlign: 'center' }}>
+                    <Typography variant="h5" color="success.main">{formatNumber(totalOutput)}</Typography>
+                    <Typography variant="caption" color="text.secondary">Output Tokens</Typography>
+                </Paper>
+                <Paper variant="outlined" sx={{ p: 2, flex: 1, textAlign: 'center' }}>
+                    <Typography variant="h5">{totalRequests}</Typography>
+                    <Typography variant="caption" color="text.secondary">Requests</Typography>
+                </Paper>
+            </Stack>
+
+            {/* Daily Usage Chart */}
+            {daily.length > 0 && (
+                <Paper variant="outlined" sx={{ p: 2, mb: 3 }}>
+                    <Typography variant="subtitle2" sx={{ mb: 1.5 }}>Daily Usage (last {daily.length} days)</Typography>
+                    <Stack spacing={0.5}>
+                        {daily.slice().reverse().map((d) => {
+                            const total = d.totalInputTokens + d.totalOutputTokens;
+                            return (
+                                <Stack key={d.date} direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                                    <Typography variant="caption" sx={{ minWidth: 80, fontFamily: 'monospace' }}>
+                                        {d.date}
+                                    </Typography>
+                                    <Box sx={{ flex: 1, position: 'relative', height: 20 }}>
+                                        <Box sx={{
+                                            position: 'absolute',
+                                            left: 0,
+                                            top: 0,
+                                            height: '100%',
+                                            width: `${(d.totalInputTokens / maxDailyTokens) * 100}%`,
+                                            bgcolor: 'info.main',
+                                            opacity: 0.7,
+                                            borderRadius: 0.5,
+                                        }} />
+                                        <Box sx={{
+                                            position: 'absolute',
+                                            left: `${(d.totalInputTokens / maxDailyTokens) * 100}%`,
+                                            top: 0,
+                                            height: '100%',
+                                            width: `${(d.totalOutputTokens / maxDailyTokens) * 100}%`,
+                                            bgcolor: 'success.main',
+                                            opacity: 0.7,
+                                            borderRadius: 0.5,
+                                        }} />
+                                    </Box>
+                                    <Typography variant="caption" sx={{ minWidth: 60, textAlign: 'right', fontFamily: 'monospace' }}>
+                                        {formatNumber(total)}
+                                    </Typography>
+                                </Stack>
+                            );
+                        })}
+                    </Stack>
+                    <Stack direction="row" spacing={2} sx={{ mt: 1 }}>
+                        <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                            <Box sx={{ width: 12, height: 12, bgcolor: 'info.main', opacity: 0.7, borderRadius: 0.5 }} />
+                            <Typography variant="caption">Input</Typography>
+                        </Stack>
+                        <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                            <Box sx={{ width: 12, height: 12, bgcolor: 'success.main', opacity: 0.7, borderRadius: 0.5 }} />
+                            <Typography variant="caption">Output</Typography>
+                        </Stack>
+                    </Stack>
+                </Paper>
+            )}
+
+            {/* Summary by Agent/Model */}
+            {summary.length > 0 && (
+                <Paper variant="outlined" sx={{ mb: 3 }}>
+                    <Typography variant="subtitle2" sx={{ p: 2, pb: 0 }}>Usage by Agent & Model</Typography>
+                    <TableContainer>
+                        <Table size="small">
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>Agent</TableCell>
+                                    <TableCell>Provider</TableCell>
+                                    <TableCell>Model</TableCell>
+                                    <TableCell align="right">Requests</TableCell>
+                                    <TableCell align="right">Input</TableCell>
+                                    <TableCell align="right">Output</TableCell>
+                                    <TableCell align="right">Avg Duration</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {summary.map((s, i) => (
+                                    <TableRow key={i}>
+                                        <TableCell>{s.agentName}</TableCell>
+                                        <TableCell>
+                                            <Chip label={s.provider} size="small" variant="outlined" />
+                                        </TableCell>
+                                        <TableCell>
+                                            <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                                                {s.model ?? '—'}
+                                            </Typography>
+                                        </TableCell>
+                                        <TableCell align="right">{s.requestCount}</TableCell>
+                                        <TableCell align="right">{formatNumber(s.totalInputTokens)}</TableCell>
+                                        <TableCell align="right">{formatNumber(s.totalOutputTokens)}</TableCell>
+                                        <TableCell align="right">{formatDuration(s.avgDurationMs)}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                </Paper>
+            )}
+
+            {/* Recent Interactions */}
+            <Paper variant="outlined">
+                <Typography variant="subtitle2" sx={{ p: 2, pb: 0 }}>Recent Interactions</Typography>
+                <TableContainer>
+                    <Table size="small">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>Time</TableCell>
+                                <TableCell>Agent</TableCell>
+                                <TableCell>Provider</TableCell>
+                                <TableCell>Model</TableCell>
+                                <TableCell align="right">Input</TableCell>
+                                <TableCell align="right">Output</TableCell>
+                                <TableCell align="right">Duration</TableCell>
+                                <TableCell align="center">Status</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {recent.map((r) => (
+                                <TableRow key={r.id}>
+                                    <TableCell>
+                                        <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                                            {new Date(r.timestampUtc).toLocaleString()}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell>{r.agentName}</TableCell>
+                                    <TableCell>
+                                        <Chip label={r.provider} size="small" variant="outlined" />
+                                    </TableCell>
+                                    <TableCell>
+                                        <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                                            {r.model ?? '—'}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell align="right">
+                                        {r.inputTokens !== null ? formatNumber(r.inputTokens) : '—'}
+                                    </TableCell>
+                                    <TableCell align="right">
+                                        {r.outputTokens !== null ? formatNumber(r.outputTokens) : '—'}
+                                    </TableCell>
+                                    <TableCell align="right">{formatDuration(r.durationMs)}</TableCell>
+                                    <TableCell align="center">
+                                        <Chip
+                                            label={r.success ? 'OK' : 'Error'}
+                                            size="small"
+                                            color={r.success ? 'success' : 'error'}
+                                            variant="outlined"
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                            {recent.length === 0 && (
+                                <TableRow>
+                                    <TableCell colSpan={8} align="center">
+                                        <Typography variant="body2" color="text.secondary" sx={{ py: 3 }}>
+                                            No token usage recorded yet.
+                                        </Typography>
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Paper>
+        </Box>
+    );
+}

--- a/SharpClaw/Api/TokenEndpoints.cs
+++ b/SharpClaw/Api/TokenEndpoints.cs
@@ -1,0 +1,44 @@
+using SharpClaw.Auditing;
+
+namespace SharpClaw.Api;
+
+public static class TokenEndpoints
+{
+    public static void MapTokenEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/tokens");
+
+        group.MapGet("/summary", (
+            TokenUsageService service,
+            string? from,
+            string? to,
+            string? agent,
+            string? provider) =>
+        {
+            var fromDate = from is not null ? DateTimeOffset.Parse(from) : (DateTimeOffset?)null;
+            var toDate = to is not null ? DateTimeOffset.Parse(to) : (DateTimeOffset?)null;
+            return Results.Ok(service.GetSummary(fromDate, toDate, agent, provider));
+        });
+
+        group.MapGet("/daily", (
+            TokenUsageService service,
+            string? from,
+            string? to,
+            string? agent,
+            string? provider) =>
+        {
+            var fromDate = from is not null ? DateTimeOffset.Parse(from) : (DateTimeOffset?)null;
+            var toDate = to is not null ? DateTimeOffset.Parse(to) : (DateTimeOffset?)null;
+            return Results.Ok(service.GetDaily(fromDate, toDate, agent, provider));
+        });
+
+        group.MapGet("/recent", (
+            TokenUsageService service,
+            int? limit,
+            string? agent,
+            string? provider) =>
+        {
+            return Results.Ok(service.GetRecent(limit ?? 50, agent, provider));
+        });
+    }
+}

--- a/SharpClaw/Auditing/TokenUsageService.cs
+++ b/SharpClaw/Auditing/TokenUsageService.cs
@@ -1,0 +1,286 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+using SharpClaw.Models;
+
+namespace SharpClaw.Auditing;
+
+public sealed class TokenUsageService : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ILogger<TokenUsageService> _logger;
+    private readonly Counter<long> _inputTokenCounter;
+    private readonly Counter<long> _outputTokenCounter;
+    private readonly Histogram<double> _durationHistogram;
+    private readonly Lock _writeLock = new();
+    private bool _disposed;
+
+    public TokenUsageService(
+        IOptions<SharpClawOptions> options,
+        IMeterFactory meterFactory,
+        ILogger<TokenUsageService> logger)
+    {
+        _logger = logger;
+
+        var workspacePath = options.Value.WorkspacePath;
+        var dbPath = !string.IsNullOrEmpty(workspacePath)
+            ? Path.Combine(workspacePath, "token-usage.db")
+            : Path.Combine(AppContext.BaseDirectory, "token-usage.db");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+
+        _connection = new SqliteConnection($"Data Source={dbPath}");
+        _connection.Open();
+        InitializeSchema();
+
+        var meter = meterFactory.Create("SharpClaw.Tokens");
+        _inputTokenCounter = meter.CreateCounter<long>("sharpclaw.tokens.input", "tokens", "Input tokens consumed");
+        _outputTokenCounter = meter.CreateCounter<long>("sharpclaw.tokens.output", "tokens", "Output tokens consumed");
+        _durationHistogram = meter.CreateHistogram<double>("sharpclaw.llm.duration_ms", "ms", "LLM request duration");
+
+        _logger.LogInformation("Token usage service initialized at {Path}", dbPath);
+    }
+
+    private void InitializeSchema()
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS token_usage (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp_utc TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                model TEXT,
+                session_id TEXT,
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                duration_ms REAL,
+                tool_count INTEGER NOT NULL DEFAULT 0,
+                mcp_count INTEGER NOT NULL DEFAULT 0,
+                skills TEXT,
+                success INTEGER NOT NULL DEFAULT 1
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_token_usage_agent ON token_usage(agent_name);
+            CREATE INDEX IF NOT EXISTS idx_token_usage_timestamp ON token_usage(timestamp_utc);
+            CREATE INDEX IF NOT EXISTS idx_token_usage_provider ON token_usage(provider);
+            CREATE INDEX IF NOT EXISTS idx_token_usage_model ON token_usage(model);
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    public void Record(TokenUsage usage)
+    {
+        lock (_writeLock)
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO token_usage (timestamp_utc, agent_name, provider, model, session_id, input_tokens, output_tokens, duration_ms, tool_count, mcp_count, skills, success)
+                VALUES (@timestamp, @agent, @provider, @model, @session, @input, @output, @duration, @tools, @mcps, @skills, @success)
+                """;
+            cmd.Parameters.AddWithValue("@timestamp", usage.TimestampUtc.ToString("O"));
+            cmd.Parameters.AddWithValue("@agent", usage.AgentName);
+            cmd.Parameters.AddWithValue("@provider", usage.Provider);
+            cmd.Parameters.AddWithValue("@model", (object?)usage.Model ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@session", (object?)usage.SessionId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@input", (object?)usage.InputTokens ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@output", (object?)usage.OutputTokens ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@duration", (object?)usage.DurationMs ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@tools", usage.ToolCount);
+            cmd.Parameters.AddWithValue("@mcps", usage.McpCount);
+            cmd.Parameters.AddWithValue("@skills", (object?)usage.Skills ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@success", usage.Success ? 1 : 0);
+            cmd.ExecuteNonQuery();
+        }
+
+        // Emit OTel metrics
+        var tags = new TagList
+        {
+            { "agent", usage.AgentName },
+            { "provider", usage.Provider },
+            { "model", usage.Model ?? "unknown" }
+        };
+
+        if (usage.InputTokens.HasValue)
+            _inputTokenCounter.Add(usage.InputTokens.Value, tags);
+
+        if (usage.OutputTokens.HasValue)
+            _outputTokenCounter.Add(usage.OutputTokens.Value, tags);
+
+        if (usage.DurationMs.HasValue)
+            _durationHistogram.Record(usage.DurationMs.Value, tags);
+
+        _logger.LogInformation(
+            "Token usage: Agent={Agent} Provider={Provider} Model={Model} Input={InputTokens} Output={OutputTokens} Duration={DurationMs:F0}ms",
+            usage.AgentName, usage.Provider, usage.Model, usage.InputTokens, usage.OutputTokens, usage.DurationMs);
+    }
+
+    public IReadOnlyList<TokenUsageSummary> GetSummary(DateTimeOffset? from = null, DateTimeOffset? to = null, string? agent = null, string? provider = null)
+    {
+        lock (_writeLock)
+        {
+            using var cmd = _connection.CreateCommand();
+            var where = BuildWhereClause(cmd, from, to, agent, provider);
+            cmd.CommandText = $"""
+                SELECT agent_name, provider, model,
+                       COUNT(*) as request_count,
+                       COALESCE(SUM(input_tokens), 0) as total_input,
+                       COALESCE(SUM(output_tokens), 0) as total_output,
+                       COALESCE(AVG(duration_ms), 0) as avg_duration
+                FROM token_usage
+                {where}
+                GROUP BY agent_name, provider, model
+                ORDER BY total_input + total_output DESC
+                """;
+
+            using var reader = cmd.ExecuteReader();
+            var results = new List<TokenUsageSummary>();
+            while (reader.Read())
+            {
+                results.Add(new TokenUsageSummary(
+                    AgentName: reader.GetString(0),
+                    Provider: reader.GetString(1),
+                    Model: reader.IsDBNull(2) ? null : reader.GetString(2),
+                    RequestCount: reader.GetInt32(3),
+                    TotalInputTokens: reader.GetInt64(4),
+                    TotalOutputTokens: reader.GetInt64(5),
+                    AvgDurationMs: reader.GetDouble(6)));
+            }
+            return results;
+        }
+    }
+
+    public IReadOnlyList<TokenUsageDaily> GetDaily(DateTimeOffset? from = null, DateTimeOffset? to = null, string? agent = null, string? provider = null)
+    {
+        lock (_writeLock)
+        {
+            using var cmd = _connection.CreateCommand();
+            var where = BuildWhereClause(cmd, from, to, agent, provider);
+            cmd.CommandText = $"""
+                SELECT DATE(timestamp_utc) as day,
+                       COUNT(*) as request_count,
+                       COALESCE(SUM(input_tokens), 0) as total_input,
+                       COALESCE(SUM(output_tokens), 0) as total_output
+                FROM token_usage
+                {where}
+                GROUP BY DATE(timestamp_utc)
+                ORDER BY day DESC
+                LIMIT 90
+                """;
+
+            using var reader = cmd.ExecuteReader();
+            var results = new List<TokenUsageDaily>();
+            while (reader.Read())
+            {
+                results.Add(new TokenUsageDaily(
+                    Date: reader.GetString(0),
+                    RequestCount: reader.GetInt32(1),
+                    TotalInputTokens: reader.GetInt64(2),
+                    TotalOutputTokens: reader.GetInt64(3)));
+            }
+            return results;
+        }
+    }
+
+    public IReadOnlyList<TokenUsage> GetRecent(int limit = 50, string? agent = null, string? provider = null)
+    {
+        lock (_writeLock)
+        {
+            using var cmd = _connection.CreateCommand();
+            var conditions = new List<string>();
+            if (!string.IsNullOrEmpty(agent))
+            {
+                conditions.Add("agent_name = @agent");
+                cmd.Parameters.AddWithValue("@agent", agent);
+            }
+            if (!string.IsNullOrEmpty(provider))
+            {
+                conditions.Add("provider = @provider");
+                cmd.Parameters.AddWithValue("@provider", provider);
+            }
+            var where = conditions.Count > 0 ? "WHERE " + string.Join(" AND ", conditions) : "";
+
+            cmd.CommandText = $"""
+                SELECT id, timestamp_utc, agent_name, provider, model, session_id, input_tokens, output_tokens, duration_ms, tool_count, mcp_count, skills, success
+                FROM token_usage
+                {where}
+                ORDER BY id DESC
+                LIMIT @limit
+                """;
+            cmd.Parameters.AddWithValue("@limit", limit);
+
+            using var reader = cmd.ExecuteReader();
+            var results = new List<TokenUsage>();
+            while (reader.Read())
+            {
+                results.Add(new TokenUsage
+                {
+                    Id = reader.GetInt64(0),
+                    TimestampUtc = DateTimeOffset.Parse(reader.GetString(1)),
+                    AgentName = reader.GetString(2),
+                    Provider = reader.GetString(3),
+                    Model = reader.IsDBNull(4) ? null : reader.GetString(4),
+                    SessionId = reader.IsDBNull(5) ? null : reader.GetString(5),
+                    InputTokens = reader.IsDBNull(6) ? null : reader.GetInt32(6),
+                    OutputTokens = reader.IsDBNull(7) ? null : reader.GetInt32(7),
+                    DurationMs = reader.IsDBNull(8) ? null : reader.GetDouble(8),
+                    ToolCount = reader.GetInt32(9),
+                    McpCount = reader.GetInt32(10),
+                    Skills = reader.IsDBNull(11) ? null : reader.GetString(11),
+                    Success = reader.GetInt32(12) == 1
+                });
+            }
+            return results;
+        }
+    }
+
+    private static string BuildWhereClause(SqliteCommand cmd, DateTimeOffset? from, DateTimeOffset? to, string? agent, string? provider)
+    {
+        var conditions = new List<string>();
+        if (from.HasValue)
+        {
+            conditions.Add("timestamp_utc >= @from");
+            cmd.Parameters.AddWithValue("@from", from.Value.ToString("O"));
+        }
+        if (to.HasValue)
+        {
+            conditions.Add("timestamp_utc <= @to");
+            cmd.Parameters.AddWithValue("@to", to.Value.ToString("O"));
+        }
+        if (!string.IsNullOrEmpty(agent))
+        {
+            conditions.Add("agent_name = @agent");
+            cmd.Parameters.AddWithValue("@agent", agent);
+        }
+        if (!string.IsNullOrEmpty(provider))
+        {
+            conditions.Add("provider = @provider");
+            cmd.Parameters.AddWithValue("@provider", provider);
+        }
+        return conditions.Count > 0 ? "WHERE " + string.Join(" AND ", conditions) : "";
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _connection.Dispose();
+    }
+}
+
+public sealed record TokenUsageSummary(
+    string AgentName,
+    string Provider,
+    string? Model,
+    int RequestCount,
+    long TotalInputTokens,
+    long TotalOutputTokens,
+    double AvgDurationMs);
+
+public sealed record TokenUsageDaily(
+    string Date,
+    int RequestCount,
+    long TotalInputTokens,
+    long TotalOutputTokens);

--- a/SharpClaw/Interactions/AgentInvoker.cs
+++ b/SharpClaw/Interactions/AgentInvoker.cs
@@ -16,6 +16,7 @@ public sealed class AgentInvoker(
     CommandRouter commandRouter,
     AuditService auditService,
     TranscriptService transcriptService,
+    TokenUsageService tokenUsageService,
     SchedulingContextAccessor schedulingContextAccessor,
     SemanticMemoryService? semanticMemory,
     MemoryExtractionService? memoryExtraction,
@@ -181,6 +182,23 @@ public sealed class AgentInvoker(
 
         // Audit the response
         await auditService.LogAsync(session.AgentId, AuditEntryType.Response, responseText ?? string.Empty, ct);
+
+        // Record token usage
+        tokenUsageService.Record(new TokenUsage
+        {
+            TimestampUtc = DateTimeOffset.UtcNow,
+            AgentName = session.AgentId,
+            Provider = agent.Llm ?? "copilot",
+            Model = agent.Model,
+            SessionId = session.SessionId,
+            InputTokens = result.InputTokens,
+            OutputTokens = result.OutputTokens,
+            DurationMs = (DateTimeOffset.UtcNow - requestStartedAt).TotalMilliseconds,
+            ToolCount = agent.ToolNames.Count,
+            McpCount = agent.McpNames.Count,
+            Skills = agent.SkillNames.Count > 0 ? string.Join(",", agent.SkillNames) : null,
+            Success = result.Success
+        });
 
         // Fire-and-forget: extract and store memories from this exchange
         if (result.Success && memoryExtraction is not null && !string.IsNullOrWhiteSpace(responseText))

--- a/SharpClaw/Models/TokenUsage.cs
+++ b/SharpClaw/Models/TokenUsage.cs
@@ -1,0 +1,19 @@
+namespace SharpClaw.Models;
+
+public sealed record TokenUsage
+{
+    public long Id { get; init; }
+    public DateTimeOffset TimestampUtc { get; init; }
+    public required string AgentName { get; init; }
+    public required string Provider { get; init; }
+    public string? Model { get; init; }
+    public string? SessionId { get; init; }
+    public int? InputTokens { get; init; }
+    public int? OutputTokens { get; init; }
+    public int? TotalTokens => (InputTokens ?? 0) + (OutputTokens ?? 0);
+    public double? DurationMs { get; init; }
+    public int ToolCount { get; init; }
+    public int McpCount { get; init; }
+    public string? Skills { get; init; }
+    public bool Success { get; init; }
+}

--- a/SharpClaw/Program.cs
+++ b/SharpClaw/Program.cs
@@ -65,6 +65,7 @@ builder.Services.AddOpenTelemetry()
             o.Protocol = OtlpExportProtocol.Grpc;
         }))
     .WithMetrics(metrics => metrics
+        .AddMeter("SharpClaw.Tokens")
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation()
         .AddOtlpExporter(o =>
@@ -148,6 +149,7 @@ builder.Services.AddSingleton<ICommand, TicketCommand>();
 builder.Services.AddSingleton<MemoryService>();
 builder.Services.AddSingleton<AuditService>();
 builder.Services.AddSingleton<TranscriptService>();
+builder.Services.AddSingleton<TokenUsageService>();
 
 // -- Semantic Memory (conditional) --
 var semanticMemoryEnabled = builder.Configuration.GetValue<bool>("SemanticMemory:Enabled");
@@ -258,6 +260,7 @@ app.MapSkillEndpoints();
 app.MapTaskEndpoints();
 app.MapConfigEndpoints();
 app.MapProjectEndpoints();
+app.MapTokenEndpoints();
 
 app.MapFallbackToFile("index.html");
 


### PR DESCRIPTION
## Summary

Implements ticket #013 — Token Tracking. Adds comprehensive token usage tracking across all LLM interactions.

## Changes

### Backend
- **`TokenUsage` model** — record with all dimensions (agent, model, provider, session, tokens, duration, tools, MCPs, skills)
- **`TokenUsageService`** — SQLite-backed storage at `{workspace}/token-usage.db` with query methods for summary, daily, and recent usage
- **OTel Metrics** — `sharpclaw.tokens.input`, `sharpclaw.tokens.output` (counters), `sharpclaw.llm.duration_ms` (histogram), all tagged by agent/provider/model
- **Structured logging** — each interaction logged with full token context for Loki queries
- **AgentInvoker integration** — records usage after every LLM call with full context
- **API endpoints**:
  - `GET /api/tokens/summary` — aggregated by agent/provider/model with date range filters
  - `GET /api/tokens/daily` — daily totals for charting
  - `GET /api/tokens/recent` — paginated recent interactions

### Frontend
- **Tokens page** with:
  - Summary cards (total, input, output tokens, request count)
  - Daily usage bar chart (stacked input/output)
  - Summary table by agent & model
  - Recent interactions table with status
  - Agent and provider filters
- **Nav item** added to sidebar with DataUsage icon

## Notes
- Copilot SDK doesn't expose token counts — those interactions will have null tokens (displayed as '—')
- Anthropic provider already captures tokens — those flow through immediately
- No retention policy yet — data accumulates. Can add pruning later if needed.