### PR TITLE
Fix System.Drawing.Primitives assembly load error for Anthropic provider

### DIFF
--- a/SharpClaw/SharpClaw.csproj
+++ b/SharpClaw/SharpClaw.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Anthropic" Version="12.23.0" />
+    <PackageReference Include="Anthropic" Version="12.29.1" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="Cronos" Version="0.8.4" />
     <PackageReference Include="GitHub.Copilot.SDK" Version="0.3.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.2" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.7" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
     <PackageReference Include="Microsoft.ML.Tokenizers" Version="1.0.1" />
@@ -35,6 +35,11 @@
     <Content Include="models/**/*.onnx" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="models/**/*.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Update="mcps/**/*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!-- Force System.Drawing.Primitives into deps.json so MEAI's source-generated JsonContext can resolve it -->
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/SharpClaw/agents/fin.agent.md
+++ b/SharpClaw/agents/fin.agent.md
@@ -1,6 +1,6 @@
 ---
 llm: anthropic
-model: claude-sonnet-4-20250514
+model: claude-sonnet-4-5-20250514
 description: Finance, investment, and economics specialist
 tools:
   - spawn_agent


### PR DESCRIPTION
## Problem

Every Anthropic provider call has been failing since June 15 with:
```
System.IO.FileNotFoundException: Could not load file or assembly 'System.Drawing.Primitives, Version=10.0.0.0'
```

The error originates in `Microsoft.Extensions.AI`'s source-generated `AIJsonUtilities.JsonContext`, which references `System.Drawing.Primitives` types when serializing tool schemas. On .NET 10, the assembly isn't resolved by the default load context.

## Changes

- **Microsoft.Extensions.AI** 10.5.2 → 10.7.0
- **Anthropic SDK** 12.23.0 → 12.29.1
- **System.Drawing.Primitives** 4.3.0 added as explicit PackageReference (safety net for assembly resolution)
- **Fin agent** model updated to `claude-sonnet-4.5`

## Testing

- Build succeeds with 0 errors
- Needs runtime verification after merge + restart