### PR TITLE
STT (Phase 1 of ticket #006): Whisper.net voice transcription

### DIFF
--- a/SharpClaw/Abstractions/ITranscriptionService.cs
+++ b/SharpClaw/Abstractions/ITranscriptionService.cs
@@ -1,0 +1,18 @@
+namespace SharpClaw.Abstractions;
+
+public interface ITranscriptionService
+{
+    bool IsAvailable { get; }
+
+    Task<TranscriptionResult> TranscribeAsync(
+        Stream audioStream,
+        string sourceFormatHint,
+        string? language = null,
+        CancellationToken ct = default);
+}
+
+public sealed record TranscriptionResult(
+    string Text,
+    string? DetectedLanguage,
+    TimeSpan Duration,
+    TimeSpan ProcessingTime);

--- a/SharpClaw/Api/ChatEndpoints.cs
+++ b/SharpClaw/Api/ChatEndpoints.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using SharpClaw.Abstractions;
 using SharpClaw.Auditing;
 using SharpClaw.Configuration;
 using SharpClaw.Interactions;
@@ -48,6 +50,74 @@ internal static class ChatEndpoints
 
             return Results.Ok(new ChatResponse(responseText, switchedTo));
         });
+
+        // Send a voice/audio message to an agent — transcribes via STT, then routes through normal flow
+        group.MapPost("/{agentName}/audio", async (
+            string agentName,
+            HttpRequest request,
+            ITranscriptionService? transcription,
+            IOptions<SttOptions> sttOptions,
+            AgentSessionRegistry sessionRegistry,
+            AgentInvoker invoker,
+            ChannelFanOutService fanOut,
+            CancellationToken ct) =>
+        {
+            if (transcription is null || !transcription.IsAvailable)
+                return Results.Problem("STT is not enabled. Set Stt:Enabled = true.", statusCode: 503);
+
+            if (!request.HasFormContentType)
+                return Results.BadRequest(new { error = "multipart/form-data required with 'audio' file field" });
+
+            var form = await request.ReadFormAsync(ct);
+            var audioFile = form.Files["audio"] ?? form.Files.FirstOrDefault();
+            if (audioFile is null || audioFile.Length == 0)
+                return Results.BadRequest(new { error = "missing 'audio' file" });
+
+            if (audioFile.Length > sttOptions.Value.MaxAudioBytes)
+                return Results.BadRequest(new { error = $"audio exceeds MaxAudioBytes ({sttOptions.Value.MaxAudioBytes})" });
+
+            var language = form["language"].FirstOrDefault();
+
+            string transcript;
+            try
+            {
+                await using var audioStream = audioFile.OpenReadStream();
+                var result = await transcription.TranscribeAsync(
+                    audioStream,
+                    audioFile.ContentType ?? "audio/unknown",
+                    language,
+                    ct);
+                transcript = result.Text;
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem($"Transcription failed: {ex.Message}", statusCode: 500);
+            }
+
+            if (string.IsNullOrWhiteSpace(transcript))
+                return Results.Ok(new AudioChatResponse(string.Empty, null, null));
+
+            var session = sessionRegistry.GetOrCreate(agentName);
+            var channelId = $"http:{Guid.NewGuid():N}";
+
+            await session.PublishAsync(new AgentMessage(
+                session.SessionId,
+                Guid.NewGuid().ToString(),
+                MessageOrigin.Web,
+                agentName,
+                transcript,
+                DateTimeOffset.UtcNow), ct);
+
+            await fanOut.BroadcastAsync(agentName, $"[web/audio] {transcript}", channelId, ct);
+
+            var schedulingCtx = new SchedulingContext(channelId, ScheduleChannelType.Web, agentName);
+            var (switchedTo, responseText) = await invoker.InvokeAsync(session, transcript, schedulingCtx, ct);
+
+            if (!string.IsNullOrEmpty(responseText))
+                await fanOut.BroadcastAsync(agentName, responseText, channelId, ct);
+
+            return Results.Ok(new AudioChatResponse(transcript, responseText, switchedTo));
+        }).DisableAntiforgery();
 
         // Get last N transcript entries for an agent
         group.MapGet("/{agentName}/history", (
@@ -112,6 +182,7 @@ internal static class ChatEndpoints
 
     private sealed record ChatRequest(string Text);
     private sealed record ChatResponse(string? Response, string? SwitchedTo);
+    private sealed record AudioChatResponse(string Transcript, string? Response, string? SwitchedTo);
     private sealed record ChatHistoryEntry(string TurnType, string Content, DateTimeOffset Timestamp);
 
     private sealed record TranscriptEntryDto(

--- a/SharpClaw/Audio/AudioConverter.cs
+++ b/SharpClaw/Audio/AudioConverter.cs
@@ -1,0 +1,103 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Audio;
+
+public sealed class AudioConverter(IOptions<SttOptions> options, ILogger<AudioConverter> logger)
+{
+    private readonly string _ffmpegPath = options.Value.FfmpegPath;
+
+    public async Task ConvertToWhisperWavAsync(
+        Stream input,
+        string inputFormatHint,
+        Stream output,
+        CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo(_ffmpegPath)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        psi.ArgumentList.Add("-hide_banner");
+        psi.ArgumentList.Add("-loglevel");
+        psi.ArgumentList.Add("error");
+        psi.ArgumentList.Add("-i");
+        psi.ArgumentList.Add("pipe:0");
+        psi.ArgumentList.Add("-ac");
+        psi.ArgumentList.Add("1");
+        psi.ArgumentList.Add("-ar");
+        psi.ArgumentList.Add("16000");
+        psi.ArgumentList.Add("-f");
+        psi.ArgumentList.Add("wav");
+        psi.ArgumentList.Add("pipe:1");
+
+        using var process = new Process { StartInfo = psi };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start ffmpeg at '{_ffmpegPath}'. Ensure ffmpeg is installed and on PATH.",
+                ex);
+        }
+
+        var stderrTask = process.StandardError.ReadToEndAsync(ct);
+
+        var copyInputTask = Task.Run(async () =>
+        {
+            try
+            {
+                await input.CopyToAsync(process.StandardInput.BaseStream, ct);
+            }
+            finally
+            {
+                process.StandardInput.Close();
+            }
+        }, ct);
+
+        var copyOutputTask = process.StandardOutput.BaseStream.CopyToAsync(output, ct);
+
+        await Task.WhenAll(copyInputTask, copyOutputTask);
+        await process.WaitForExitAsync(ct);
+
+        if (process.ExitCode != 0)
+        {
+            var stderr = await stderrTask;
+            logger.LogWarning(
+                "ffmpeg failed with exit code {Code} (input format hint: {Hint}). stderr: {Stderr}",
+                process.ExitCode, inputFormatHint, stderr);
+            throw new InvalidOperationException(
+                $"Audio conversion failed (ffmpeg exit {process.ExitCode}): {stderr}");
+        }
+    }
+
+    public async Task<bool> IsFfmpegAvailableAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(_ffmpegPath, "-version")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            if (process is null) return false;
+            await process.WaitForExitAsync(ct);
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/SharpClaw/Audio/WhisperModelDownloader.cs
+++ b/SharpClaw/Audio/WhisperModelDownloader.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Audio;
+
+public sealed class WhisperModelDownloader(
+    IOptions<SttOptions> options,
+    IHttpClientFactory httpClientFactory,
+    ILogger<WhisperModelDownloader> logger)
+{
+    private const string BaseUrl = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main";
+
+    private static readonly HashSet<string> ValidSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "tiny", "tiny.en", "base", "base.en", "small", "small.en",
+        "medium", "medium.en", "large-v1", "large-v2", "large-v3"
+    };
+
+    private readonly SttOptions _options = options.Value;
+
+    public string GetModelPath()
+    {
+        var size = _options.ModelSize;
+        if (!ValidSizes.Contains(size))
+        {
+            throw new InvalidOperationException(
+                $"Invalid Stt:ModelSize '{size}'. Valid: {string.Join(", ", ValidSizes)}");
+        }
+
+        Directory.CreateDirectory(_options.ModelDirectory);
+        return Path.Combine(_options.ModelDirectory, $"ggml-{size}.bin");
+    }
+
+    public async Task<string> EnsureModelAsync(CancellationToken ct = default)
+    {
+        var path = GetModelPath();
+
+        if (File.Exists(path) && new FileInfo(path).Length > 0)
+        {
+            return path;
+        }
+
+        if (!_options.AutoDownload)
+        {
+            throw new FileNotFoundException(
+                $"Whisper model not found at '{path}' and Stt:AutoDownload is disabled.", path);
+        }
+
+        var url = $"{BaseUrl}/ggml-{_options.ModelSize}.bin";
+        logger.LogInformation("Downloading whisper model {Size} from {Url} → {Path}",
+            _options.ModelSize, url, path);
+
+        var http = httpClientFactory.CreateClient("whisper-models");
+        http.Timeout = TimeSpan.FromMinutes(10);
+
+        var tempPath = path + ".part";
+        try
+        {
+            using (var response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct))
+            {
+                response.EnsureSuccessStatusCode();
+                await using var input = await response.Content.ReadAsStreamAsync(ct);
+                await using var output = File.Create(tempPath);
+                await input.CopyToAsync(output, ct);
+            }
+
+            File.Move(tempPath, path, overwrite: true);
+            logger.LogInformation("Whisper model downloaded: {Size} ({Bytes:N0} bytes)",
+                _options.ModelSize, new FileInfo(path).Length);
+            return path;
+        }
+        catch
+        {
+            try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { /* best effort */ }
+            throw;
+        }
+    }
+}

--- a/SharpClaw/Audio/WhisperTranscriptionService.cs
+++ b/SharpClaw/Audio/WhisperTranscriptionService.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Options;
+using SharpClaw.Abstractions;
+using SharpClaw.Configuration;
+using Whisper.net;
+
+namespace SharpClaw.Audio;
+
+public sealed class WhisperTranscriptionService(
+    IOptions<SttOptions> options,
+    WhisperModelDownloader modelDownloader,
+    AudioConverter audioConverter,
+    ILogger<WhisperTranscriptionService> logger) : ITranscriptionService, IDisposable
+{
+    private readonly SttOptions _options = options.Value;
+    private readonly SemaphoreSlim _concurrency = new(Math.Max(1, options.Value.MaxConcurrency));
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private WhisperFactory? _factory;
+    private bool _disposed;
+
+    public bool IsAvailable => _options.Enabled;
+
+    public async Task<TranscriptionResult> TranscribeAsync(
+        Stream audioStream,
+        string sourceFormatHint,
+        string? language = null,
+        CancellationToken ct = default)
+    {
+        if (!_options.Enabled)
+            throw new InvalidOperationException("STT is disabled. Set Stt:Enabled = true.");
+
+        var totalSw = Stopwatch.StartNew();
+
+        await using var wavStream = new MemoryStream();
+        await audioConverter.ConvertToWhisperWavAsync(audioStream, sourceFormatHint, wavStream, ct);
+        wavStream.Position = 0;
+
+        await EnsureFactoryAsync(ct);
+
+        await _concurrency.WaitAsync(ct);
+        try
+        {
+            var lang = string.IsNullOrWhiteSpace(language) ? _options.Language : language;
+
+            var processorBuilder = _factory!.CreateBuilder()
+                .WithSegmentEventHandler(_ => { });
+
+            processorBuilder = string.Equals(lang, "auto", StringComparison.OrdinalIgnoreCase)
+                ? processorBuilder.WithLanguage("auto")
+                : processorBuilder.WithLanguage(lang);
+
+            using var processor = processorBuilder.Build();
+
+            var processSw = Stopwatch.StartNew();
+            var segments = new List<string>();
+            string? detectedLanguage = null;
+
+            await foreach (var segment in processor.ProcessAsync(wavStream, ct))
+            {
+                segments.Add(segment.Text);
+                detectedLanguage ??= segment.Language;
+            }
+            processSw.Stop();
+
+            var text = string.Concat(segments).Trim();
+
+            logger.LogInformation(
+                "Transcribed audio in {ProcessMs}ms (total {TotalMs}ms, lang={Lang}, chars={Chars}, model={Model})",
+                processSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds,
+                detectedLanguage ?? lang, text.Length, _options.ModelSize);
+
+            return new TranscriptionResult(
+                Text: text,
+                DetectedLanguage: detectedLanguage,
+                Duration: TimeSpan.Zero,
+                ProcessingTime: processSw.Elapsed);
+        }
+        finally
+        {
+            _concurrency.Release();
+        }
+    }
+
+    private async Task EnsureFactoryAsync(CancellationToken ct)
+    {
+        if (_factory is not null) return;
+
+        await _initLock.WaitAsync(ct);
+        try
+        {
+            if (_factory is not null) return;
+
+            var modelPath = await modelDownloader.EnsureModelAsync(ct);
+            logger.LogInformation("Loading Whisper model from {Path}", modelPath);
+            _factory = WhisperFactory.FromPath(modelPath);
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _factory?.Dispose();
+        _concurrency.Dispose();
+        _initLock.Dispose();
+    }
+}

--- a/SharpClaw/Configuration/SttOptions.cs
+++ b/SharpClaw/Configuration/SttOptions.cs
@@ -1,0 +1,22 @@
+namespace SharpClaw.Configuration;
+
+public sealed class SttOptions
+{
+    public const string SectionName = "Stt";
+
+    public bool Enabled { get; set; }
+
+    public string ModelSize { get; set; } = "base";
+
+    public string ModelDirectory { get; set; } = "models/whisper";
+
+    public bool AutoDownload { get; set; } = true;
+
+    public string Language { get; set; } = "auto";
+
+    public int MaxConcurrency { get; set; } = 1;
+
+    public string FfmpegPath { get; set; } = "ffmpeg";
+
+    public int MaxAudioBytes { get; set; } = 25 * 1024 * 1024;
+}

--- a/SharpClaw/Program.cs
+++ b/SharpClaw/Program.cs
@@ -6,6 +6,7 @@ using OpenTelemetry.Trace;
 using Telegram.Bot;
 using SharpClaw.Abstractions;
 using SharpClaw.Api;
+using SharpClaw.Audio;
 using SharpClaw.Auditing;
 using SharpClaw.Commands;
 using SharpClaw.Configuration;
@@ -42,6 +43,7 @@ builder.Services.Configure<OpenTelemetryOptions>(builder.Configuration.GetSectio
 builder.Services.Configure<AnthropicOptions>(builder.Configuration.GetSection(AnthropicOptions.SectionName));
 builder.Services.Configure<AnthropicAdminMcpOptions>(builder.Configuration.GetSection(AnthropicAdminMcpOptions.SectionName));
 builder.Services.Configure<SemanticMemoryOptions>(builder.Configuration.GetSection(SemanticMemoryOptions.SectionName));
+builder.Services.Configure<SttOptions>(builder.Configuration.GetSection(SttOptions.SectionName));
 
 // -- Logging: Console with custom format --
 builder.Logging.ClearProviders();
@@ -177,6 +179,22 @@ else
     builder.Services.AddSingleton<SemanticMemoryService?>(sp => null);
     builder.Services.AddSingleton<MemoryExtractionService?>(sp => null);
     builder.Services.AddSingleton<MemoryImportService?>(sp => null);
+}
+
+// -- STT (Speech-to-Text) — conditional --
+var sttEnabled = builder.Configuration.GetValue<bool>("Stt:Enabled");
+if (sttEnabled)
+{
+    builder.Services.AddHttpClient();
+    builder.Services.AddSingleton<AudioConverter>();
+    builder.Services.AddSingleton<WhisperModelDownloader>();
+    builder.Services.AddSingleton<WhisperTranscriptionService>();
+    builder.Services.AddSingleton<ITranscriptionService>(sp =>
+        sp.GetRequiredService<WhisperTranscriptionService>());
+}
+else
+{
+    builder.Services.AddSingleton<ITranscriptionService?>(sp => null);
 }
 
 // -- Workspace --

--- a/SharpClaw/SharpClaw.csproj
+++ b/SharpClaw/SharpClaw.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="Telegram.Bot" Version="22.9.5.3" />
+    <PackageReference Include="Whisper.net" Version="1.9.1" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpClaw/Telegram/TelegramService.cs
+++ b/SharpClaw/Telegram/TelegramService.cs
@@ -25,6 +25,7 @@ public sealed class TelegramService(
     ChannelFanOutService fanOut,
     IOptions<TelegramOptions> telegramOptions,
     IOptions<SharpClawOptions> sharpClawOptions,
+    ITranscriptionService? transcriptionService,
     ILogger<TelegramService> logger) : BackgroundService
 {
     private const int TelegramMessageChunkSize = 3500;
@@ -115,6 +116,26 @@ public sealed class TelegramService(
             text = message.Caption;
         }
 
+        // Handle voice / audio / video notes via STT
+        if (message.Voice is not null || message.Audio is not null || message.VideoNote is not null)
+        {
+            var transcribed = await TranscribeVoiceAsync(message, chatId, ct);
+            if (transcribed is not null)
+            {
+                // Echo transcription back so the user can verify what was heard.
+                await SendResponseAsync(chatId, $"🎤 _{transcribed}_", ct);
+
+                text = string.IsNullOrWhiteSpace(message.Caption)
+                    ? transcribed
+                    : $"{message.Caption}\n\n{transcribed}";
+            }
+            else if (text is null && fileContext is null)
+            {
+                // Transcription failed and there's no other content
+                return;
+            }
+        }
+
         // Must have either text or a file to process
         if (text is null && fileContext is null) return;
 
@@ -167,6 +188,69 @@ public sealed class TelegramService(
         {
             await typingCts.CancelAsync();
             try { await typingTask; } catch (OperationCanceledException) { }
+        }
+    }
+
+    private async Task<string?> TranscribeVoiceAsync(Message message, long chatId, CancellationToken ct)
+    {
+        if (transcriptionService is null || !transcriptionService.IsAvailable)
+        {
+            await SendResponseAsync(chatId,
+                "_Voice messages aren't enabled. Set Stt:Enabled = true to use them._", ct);
+            return null;
+        }
+
+        string? fileId;
+        string formatHint;
+
+        if (message.Voice is { } voice)
+        {
+            fileId = voice.FileId;
+            formatHint = voice.MimeType ?? "audio/ogg";
+        }
+        else if (message.Audio is { } audio)
+        {
+            fileId = audio.FileId;
+            formatHint = audio.MimeType ?? "audio/mpeg";
+        }
+        else if (message.VideoNote is { } videoNote)
+        {
+            fileId = videoNote.FileId;
+            formatHint = "video/mp4";
+        }
+        else
+        {
+            return null;
+        }
+
+        try
+        {
+            var file = await botClient.GetFile(fileId, ct);
+            if (file.FilePath is null)
+            {
+                logger.LogWarning("Telegram returned no file path for voice FileId {FileId}", fileId);
+                return null;
+            }
+
+            await using var audioStream = new MemoryStream();
+            await botClient.DownloadFile(file.FilePath, audioStream, ct);
+            audioStream.Position = 0;
+
+            var result = await transcriptionService.TranscribeAsync(audioStream, formatHint, language: null, ct);
+
+            if (string.IsNullOrWhiteSpace(result.Text))
+            {
+                await SendResponseAsync(chatId, "_(no speech detected in voice message)_", ct);
+                return null;
+            }
+
+            return result.Text;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Voice transcription failed for chat {ChatId}", chatId);
+            await SendResponseAsync(chatId, $"_Voice transcription failed: {ex.Message}_", ct);
+            return null;
         }
     }
 

--- a/SharpClaw/appsettings.json
+++ b/SharpClaw/appsettings.json
@@ -44,5 +44,15 @@
     "ExtractionMaxTokens": 1024,
     "MinPromptLengthForExtraction": 20,
     "MinResponseLengthForExtraction": 50
+  },
+  "Stt": {
+    "Enabled": false,
+    "ModelSize": "base",
+    "ModelDirectory": "models/whisper",
+    "AutoDownload": true,
+    "Language": "auto",
+    "MaxConcurrency": 1,
+    "FfmpegPath": "ffmpeg",
+    "MaxAudioBytes": 26214400
   }
 }

--- a/docs/docs/features/stt.md
+++ b/docs/docs/features/stt.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 16
+---
+
+# Speech-to-Text (STT)
+
+SharpClaw can transcribe voice and audio messages on Telegram and the web chat using
+[Whisper.net](https://github.com/sandrohanea/whisper.net) — C# bindings for `whisper.cpp`.
+All inference runs locally on CPU. No GPU or Python dependency.
+
+## How it works
+
+1. A user sends a voice message (Telegram) or uploads audio (web chat).
+2. SharpClaw downloads the audio bytes and pipes them to `ffmpeg`, which converts to
+   16 kHz mono PCM WAV.
+3. The WAV stream is passed to a shared `WhisperFactory` (one ggml model loaded once,
+   per-call processors created on top).
+4. The transcript is fed back into the normal agent invocation pipeline, exactly as
+   if the user had typed it.
+
+## Requirements
+
+- **`ffmpeg`** must be installed and on `PATH`. On Debian/Ubuntu: `sudo apt install ffmpeg`.
+- A ggml whisper model file. By default SharpClaw will download the `base` model from
+  HuggingFace on first use (~150 MB).
+
+## Configuration
+
+```json
+{
+  "Stt": {
+    "Enabled": false,
+    "ModelSize": "base",
+    "ModelDirectory": "models/whisper",
+    "AutoDownload": true,
+    "Language": "auto",
+    "MaxConcurrency": 1,
+    "FfmpegPath": "ffmpeg",
+    "MaxAudioBytes": 26214400
+  }
+}
+```
+
+| Option | Description |
+|--------|-------------|
+| `Enabled` | Master switch. When `false`, no STT services are registered. |
+| `ModelSize` | One of `tiny`, `base`, `small`, `medium`, `large-v3` (or `.en` variants). |
+| `ModelDirectory` | Where ggml `.bin` model files live. |
+| `AutoDownload` | If `true`, missing models are downloaded from HuggingFace on first request. |
+| `Language` | ISO code (e.g. `en`, `de`) or `auto` for whisper to detect. |
+| `MaxConcurrency` | Bounded semaphore — number of concurrent transcriptions. |
+| `FfmpegPath` | Path to the ffmpeg executable. |
+| `MaxAudioBytes` | Reject audio uploads larger than this (web endpoint). |
+
+## Model size guide
+
+| Size | Disk | RAM | Quality |
+|------|------|-----|---------|
+| `tiny` | 75 MB | ~390 MB | Lowest, fastest |
+| `base` | 150 MB | ~500 MB | Good default |
+| `small` | 500 MB | ~1 GB | Better accuracy |
+| `medium` | 1.5 GB | ~2.6 GB | High accuracy |
+| `large-v3` | 3 GB | ~4.7 GB | Best |
+
+`.en` variants are English-only and slightly more accurate for English speech.
+
+## Pre-downloading a model
+
+```bash
+./scripts/download-whisper-model.sh base
+```
+
+## Telegram
+
+When `Stt:Enabled = true`, voice messages, audio files, and round video notes sent to
+the bot are automatically transcribed. The transcript is echoed back to the user as a
+quoted line (`🎤 _your text_`) so they can verify what was heard, then routed to the
+agent as if they had typed it. If the message also has a caption, the caption is
+prepended to the transcript.
+
+## Web chat
+
+`POST /api/chat/{agentName}/audio` accepts `multipart/form-data` with an `audio` file
+field and an optional `language` field. It returns:
+
+```json
+{
+  "transcript": "what the model heard",
+  "response": "the agent's reply",
+  "switchedTo": null
+}
+```
+
+## Operational notes
+
+- The ggml model is loaded **lazily on first request** and kept in memory for the
+  process lifetime.
+- Concurrency is bounded by `Stt:MaxConcurrency`. Whisper inference is CPU-heavy;
+  increase only if you have spare cores.
+- If transcription fails (ffmpeg missing, model download blocked, etc.) the user
+  receives a clear error message — the agent invocation is skipped, not retried.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -23,6 +23,7 @@ const sidebars: SidebarsConfig = {
         'features/projects',
         'features/auditing',
         'features/logging',
+        'features/stt',
       ],
     },
   ],

--- a/scripts/download-whisper-model.sh
+++ b/scripts/download-whisper-model.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Download a Whisper.cpp ggml model from HuggingFace.
+# Usage: ./scripts/download-whisper-model.sh [size]
+#   size: tiny | base | small | medium | large-v3 (default: base)
+
+set -euo pipefail
+
+SIZE="${1:-base}"
+DIR="${WHISPER_MODEL_DIR:-SharpClaw/models/whisper}"
+URL="https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-${SIZE}.bin"
+OUT="${DIR}/ggml-${SIZE}.bin"
+
+mkdir -p "$DIR"
+
+if [[ -f "$OUT" && -s "$OUT" ]]; then
+    echo "Model already present: $OUT ($(du -h "$OUT" | cut -f1))"
+    exit 0
+fi
+
+echo "Downloading $URL → $OUT"
+curl -L --fail --progress-bar -o "$OUT.part" "$URL"
+mv "$OUT.part" "$OUT"
+echo "Done: $OUT ($(du -h "$OUT" | cut -f1))"


### PR DESCRIPTION
Phase 1 of [ticket #006](https://github.com/kjhughes097/sharpclaw/blob/main/projects/sharpclaw/tickets/006.md) — speech-to-text for Telegram voice messages and web chat audio uploads.

## What this does

- Voice/audio messages on Telegram are auto-transcribed and routed to the agent as if typed.
- New `POST /api/chat/{agent}/audio` endpoint for the web UI.
- All inference local/CPU via Whisper.net (whisper.cpp bindings) — no GPU, no Python.

## Components

- `ITranscriptionService` + `WhisperTranscriptionService` (singleton, lazy model load, bounded concurrency)
- `AudioConverter` — pipes audio through `ffmpeg` for OGG/Opus → 16kHz mono WAV
- `WhisperModelDownloader` — auto-fetches ggml models from HuggingFace on first use
- `TelegramService` updated to handle `Voice`, `Audio`, `VideoNote` (echoes 🎤 transcript back so user can verify what was heard)
- `SttOptions` config section, **disabled by default**
- `scripts/download-whisper-model.sh` helper
- New docs page `features/stt.md`

## Runtime requirements

- `ffmpeg` on PATH (`apt install ffmpeg`)
- A ggml whisper model (auto-downloaded when first used; `base` ≈ 150MB)

## Verification

- `dotnet build` → clean (0 errors)
- `dotnet test` → 20/21 pass (1 pre-existing failure in PingCommand test, unrelated to STT)
- `cd docs && npm run build` → clean

## Deferred

Phase 2 (TTS — agent voice replies) intentionally deferred to a separate ticket/PR.

🤖 Generated with Cody