### PR TITLE
Localize date formatting in web UI (ticket #020)

### DIFF
--- a/SharpClaw.Web/src/pages/TaskEditorPage.tsx
+++ b/SharpClaw.Web/src/pages/TaskEditorPage.tsx
@@ -19,11 +19,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import Editor from '@monaco-editor/react';
 import { getTask, updateTask, deleteTask } from '../api/tasks';
 import type { ScheduledTaskDetail } from '../api/tasks';
-
-function formatDate(iso: string | null): string {
-    if (!iso) return '—';
-    return new Date(iso).toLocaleString();
-}
+import { formatDateTime } from '../utils/dateFormat';
 
 export default function TaskEditorPage() {
     const { id } = useParams<{ id: string }>();
@@ -191,13 +187,13 @@ export default function TaskEditorPage() {
                             Channel: {task.channelType} ({task.channelKey})
                         </Typography>
                         <Typography variant="caption" color="text.secondary">
-                            Created: {formatDate(task.created)}
+                            Created: {formatDateTime(task.created)}
                         </Typography>
                         <Typography variant="caption" color="text.secondary">
-                            Next run: {formatDate(task.nextRun)}
+                            Next run: {formatDateTime(task.nextRun)}
                         </Typography>
                         <Typography variant="caption" color="text.secondary">
-                            Last run: {formatDate(task.lastRun)}
+                            Last run: {formatDateTime(task.lastRun)}
                         </Typography>
                     </Stack>
                 </Stack>

--- a/SharpClaw.Web/src/pages/TaskListPage.tsx
+++ b/SharpClaw.Web/src/pages/TaskListPage.tsx
@@ -12,11 +12,7 @@ import Stack from '@mui/material/Stack';
 import AddIcon from '@mui/icons-material/Add';
 import { getTasks } from '../api/tasks';
 import type { ScheduledTaskSummary } from '../api/tasks';
-
-function formatDate(iso: string | null): string {
-    if (!iso) return '—';
-    return new Date(iso).toLocaleString();
-}
+import { formatDateTime } from '../utils/dateFormat';
 
 export default function TaskListPage() {
     const [tasks, setTasks] = useState<ScheduledTaskSummary[]>([]);
@@ -75,10 +71,10 @@ export default function TaskListPage() {
                                 </Stack>
 
                                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                                    Next run: {formatDate(task.nextRun)}
+                                    Next run: {formatDateTime(task.nextRun)}
                                 </Typography>
                                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                                    Last run: {formatDate(task.lastRun)}
+                                    Last run: {formatDateTime(task.lastRun)}
                                 </Typography>
 
                                 {task.prompt && (

--- a/SharpClaw.Web/src/pages/TokensPage.tsx
+++ b/SharpClaw.Web/src/pages/TokensPage.tsx
@@ -14,6 +14,7 @@ import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import { getTokenSummary, getTokenDaily, getTokenRecent } from '../api/tokens';
 import type { TokenUsageSummary, TokenUsageDaily, TokenUsageEntry } from '../api/tokens';
+import { formatDate, formatDateTime } from '../utils/dateFormat';
 
 function formatNumber(n: number): string {
     if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -119,7 +120,7 @@ export default function TokensPage() {
                             return (
                                 <Stack key={d.date} direction="row" spacing={1} sx={{ alignItems: 'center' }}>
                                     <Typography variant="caption" sx={{ minWidth: 80, fontFamily: 'monospace' }}>
-                                        {d.date}
+                                        {formatDate(d.date)}
                                     </Typography>
                                     <Box sx={{ flex: 1, position: 'relative', height: 20 }}>
                                         <Box sx={{
@@ -226,7 +227,7 @@ export default function TokensPage() {
                                 <TableRow key={r.id}>
                                     <TableCell>
                                         <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-                                            {new Date(r.timestampUtc).toLocaleString()}
+                                            {formatDateTime(r.timestampUtc)}
                                         </Typography>
                                     </TableCell>
                                     <TableCell>{r.agentName}</TableCell>

--- a/SharpClaw.Web/src/utils/dateFormat.ts
+++ b/SharpClaw.Web/src/utils/dateFormat.ts
@@ -1,0 +1,28 @@
+function getLocale(): string | undefined {
+    if (typeof navigator === 'undefined') return undefined;
+    return navigator.languages?.[0] ?? navigator.language ?? undefined;
+}
+
+function parseDate(value: string | null | undefined): Date | null {
+    if (!value) return null;
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function formatDateTime(value: string | null | undefined, fallback = '—'): string {
+    const d = parseDate(value);
+    if (!d) return fallback;
+    return d.toLocaleString(getLocale());
+}
+
+export function formatDate(value: string | null | undefined, fallback = '—'): string {
+    const d = parseDate(value);
+    if (!d) return fallback;
+    return d.toLocaleDateString(getLocale());
+}
+
+export function formatTime(value: string | null | undefined, fallback = '—'): string {
+    const d = parseDate(value);
+    if (!d) return fallback;
+    return d.toLocaleTimeString(getLocale());
+}


### PR DESCRIPTION
Closes ticket #020.

Adds `SharpClaw.Web/src/utils/dateFormat.ts` with `formatDateTime`, `formatDate`, and `formatTime` helpers that pass `navigator.language` (preferring `navigator.languages[0]`) to the `toLocale*` APIs. This guarantees the browser locale is used rather than relying on the JS runtime default.

Updated pages:
- `TaskListPage` — next/last run
- `TaskEditorPage` — created, next/last run
- `TokensPage` — daily chart row labels and recent-usage timestamps

UK browsers now see dd/mm/yyyy; en-US see mm/dd/yyyy; de-DE see dd.mm.yyyy; etc.

Verified: `npm run build` passes.