### PR TITLE
Fix .restart silently dropping changes

### DIFF
--- a/SharpClaw/Commands/RestartCommand.cs
+++ b/SharpClaw/Commands/RestartCommand.cs
@@ -59,8 +59,21 @@ public sealed class RestartCommand(
             }
         }
 
-        // Build first
         var repoRoot = GetRepoRoot();
+
+        // Surface any build failure from a previous restart attempt so the user
+        // isn't left wondering why a prior .restart silently did nothing.
+        var failFile = Path.Combine(repoRoot, ".sharpclaw.restart.failed");
+        string? priorFailure = null;
+        if (File.Exists(failFile))
+        {
+            try { priorFailure = (await File.ReadAllTextAsync(failFile, ct)).Trim(); } catch { }
+            try { File.Delete(failFile); } catch { }
+        }
+
+        // Validate the build BEFORE killing the process. The watcher will
+        // build again after stopping the process (when file locks are
+        // released), but failing fast here gives immediate feedback.
         var projectPath = Path.Combine("SharpClaw", "SharpClaw.csproj");
         var buildResult = await RunBuildAsync(repoRoot, projectPath, ct);
 
@@ -76,8 +89,12 @@ public sealed class RestartCommand(
         await File.WriteAllTextAsync(signalFile, DateTime.UtcNow.ToString("O"), ct);
         logger.LogInformation("Restart signal written to {SignalFile}", signalFile);
 
+        var prefix = priorFailure is null
+            ? string.Empty
+            : $"⚠️ Previous restart failed in watcher: `{priorFailure}` (cleared)\n\n";
+
         return new CommandResult(true,
-            "✅ **Build succeeded** — restart signal sent. SharpClaw will restart momentarily.");
+            prefix + "✅ **Build succeeded** — restart signal sent. SharpClaw will restart momentarily.");
     }
 
     private async Task<CommandResult> RestartManagedServiceAsync(string name, CancellationToken ct)

--- a/sharpclaw.sh
+++ b/sharpclaw.sh
@@ -238,35 +238,48 @@ start_watcher() {
     SIGNAL_FILE="${ROOT_DIR}/.sharpclaw.restart"
     PROJECT="'"$(resolve_project)"'"
 
+    FAIL_FILE="${ROOT_DIR}/.sharpclaw.restart.failed"
+
     while true; do
       sleep 2
       [[ -f "${SIGNAL_FILE}" ]] || continue
 
       rm -f "${SIGNAL_FILE}"
-      echo "[watcher] Restart signal detected. Rebuilding..." >> "${LOG_FILE}"
+      rm -f "${FAIL_FILE}"
+      echo "[watcher] Restart signal detected." >> "${LOG_FILE}"
 
-      # Pull latest changes
-      cd "${ROOT_DIR}"
-      git pull --quiet >> "${LOG_FILE}" 2>&1 || true
-
-      # Build first
-      if ! dotnet build "${PROJECT}" --nologo -q >> "${LOG_FILE}" 2>&1; then
-        echo "[watcher] Build failed — restart aborted." >> "${LOG_FILE}"
-        continue
-      fi
-
-      # Stop current process
+      # Stop current process FIRST so it releases locks on bin/ and obj/.
+      # Building while the old app holds file handles intermittently fails
+      # with MSB3492 ("could not read ... AssemblyInfoInputs.cache") and
+      # leaves the user thinking nothing happened.
       if [[ -f "${PID_FILE}" ]]; then
         pid="$(cat "${PID_FILE}")"
         if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+          echo "[watcher] Stopping old SharpClaw (PID ${pid})..." >> "${LOG_FILE}"
           kill "${pid}" 2>/dev/null || true
-          for i in {1..20}; do
+          for i in {1..40}; do
             kill -0 "${pid}" 2>/dev/null || break
             sleep 0.25
           done
           kill -0 "${pid}" 2>/dev/null && kill -9 "${pid}" 2>/dev/null || true
         fi
         rm -f "${PID_FILE}"
+      fi
+
+      # Pull latest changes (after stop, before build)
+      cd "${ROOT_DIR}"
+      git pull --quiet >> "${LOG_FILE}" 2>&1 || true
+
+      # Build with the old process gone — no file locks, deterministic result.
+      # NOTE: do NOT pass `-q` here. In `dotnet build`, `-q` is forwarded to
+      # MSBuild as `--question` (the up-to-date check) and exits non-zero
+      # whenever there is anything to compile — which is exactly when we
+      # want to actually build. Output is redirected to LOG_FILE anyway.
+      echo "[watcher] Building..." >> "${LOG_FILE}"
+      if ! dotnet build "${PROJECT}" --nologo -v q >> "${LOG_FILE}" 2>&1; then
+        echo "[watcher] Build failed — service will NOT be restarted." >> "${LOG_FILE}"
+        date -u +"%Y-%m-%dT%H:%M:%SZ build failed after .restart" > "${FAIL_FILE}"
+        continue
       fi
 
       # Start new process


### PR DESCRIPTION
## The bug

Ken reported that merging a PR and running `.restartf` did not pick up the new code, sometimes repeatedly. This investigation found **two compounding bugs** in the restart watcher in `sharpclaw.sh`.

### 1. `-q` is not "quiet" in `dotnet build`

The watcher ran:
```bash
dotnet build "${PROJECT}" --nologo -q
```

`dotnet build` has no `-q` short option. It gets forwarded to MSBuild as **`--question`** — the up-to-date check that exits non-zero if anything would need building.

So whenever `git pull` actually brought in new source files (i.e. exactly the case the user cares about), the watcher's "build" returned failure without ever compiling, and `Build failed — restart aborted` fired silently. When sources happened to match binaries, it succeeded but no new code was produced. Either way, merged changes never made it into the running process.

Confirmed against the live log:
```
Question build FAILED. The build exited early as it encountered a target or task that was not up-to-date.
[watcher] Build failed — restart aborted.
```

Fixed by using the correct verbosity flag `-v q`.

### 2. Build raced with the live process for file locks

The watcher built **before** stopping the old SharpClaw process. With the app actively serving HTTP requests, files in `obj/` and `bin/` are intermittently locked, producing MSB3492 `Could not read existing file ... AssemblyInfoInputs.cache` errors that also aborted the restart. This was the source of the intermittent successes.

Reordered the watcher to: **stop process → git pull → build → start**, so the build always runs against unlocked files.

### 3. Silent failure feedback

When the watcher aborted, the user had already been told `✅ Build succeeded — restart signal sent` by `RestartCommand` and had no way of knowing the watcher then bailed. The watcher now writes `.sharpclaw.restart.failed` on failure, and the next `.restart` reports and clears it.

## Files changed

- `sharpclaw.sh` — fix `-q` → `-v q`, reorder kill/build, add fail marker
- `SharpClaw/Commands/RestartCommand.cs` — surface prior watcher failures

## Testing

`dotnet build SharpClaw/SharpClaw.csproj --nologo -v q` → 0 errors, 16 pre-existing warnings.