### PR TITLE
Default new tickets to Idea status

### DIFF
--- a/SharpClaw/Loading/ProjectLoader.cs
+++ b/SharpClaw/Loading/ProjectLoader.cs
@@ -145,7 +145,7 @@ public sealed class ProjectLoader(
 
         var nextId = GetNextTicketId();
         var now = DateTimeOffset.UtcNow;
-        var ticket = new Ticket(nextId, projectId, title, description, TicketStatus.Planning, now, now, labels ?? [], reporter, assignee);
+        var ticket = new Ticket(nextId, projectId, title, description, TicketStatus.Idea, now, now, labels ?? [], reporter, assignee);
 
         var file = Path.Combine(ticketsDir, $"{nextId}.md");
         WriteTicketFile(file, ticket);


### PR DESCRIPTION
New tickets created via `ProjectLoader.CreateTicket` were defaulting to `Planning`, which skipped the human triage step described in the ticket-workflow skill ("You may create new tickets with status `idea`").

Changes `TicketStatus.Planning` → `TicketStatus.Idea` in `ProjectLoader.CreateTicket` so tickets land in `idea` and a human moves them forward.

Build: clean.