### PR TITLE
Add 'Blocked' ticket status (sharpclaw/021)

### DIFF
--- a/SharpClaw.Web/src/pages/ProjectsPage.tsx
+++ b/SharpClaw.Web/src/pages/ProjectsPage.tsx
@@ -26,11 +26,12 @@ import Editor from '@monaco-editor/react';
 import { getProjects, getProjectTickets, getUsers, getLabels, addLabel, removeLabel, createProject, deleteProject, updateTicketStatus, updateTicket, createTicket, improveTicket, moveTicket, deleteTicket } from '../api/projects';
 import type { ProjectSummary, TicketSummary, User } from '../api/projects';
 
-const STATUSES = [
+const STATUSES: { key: string; label: string; accent?: string }[] = [
     { key: 'idea', label: 'Idea' },
     { key: 'planning', label: 'Planning' },
     { key: 'todo', label: 'Todo' },
     { key: 'in_progress', label: 'In Progress' },
+    { key: 'blocked', label: 'Blocked', accent: '#d32f2f' },
     { key: 'for_review', label: 'For Review' },
     { key: 'done', label: 'Done' },
 ];
@@ -330,7 +331,7 @@ export default function ProjectsPage() {
             )}
 
             <Box sx={{ display: 'flex', gap: 1, pb: 2, width: '100%' }}>
-                {STATUSES.map(({ key, label }) => (
+                {STATUSES.map(({ key, label, accent }) => (
                     <Paper
                         key={key}
                         variant="outlined"
@@ -343,10 +344,11 @@ export default function ProjectsPage() {
                             p: 1.5,
                             bgcolor: dragOverStatus === key ? 'action.hover' : 'background.default',
                             transition: 'background-color 0.15s',
+                            ...(accent ? { borderColor: accent, borderTopWidth: 3 } : {}),
                         }}
                     >
                         <Stack direction="row" spacing={1} sx={{ mb: 1.5, alignItems: 'center' }}>
-                            <Typography variant="subtitle2" sx={{ fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                            <Typography variant="subtitle2" sx={{ fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5, color: accent ?? 'inherit' }}>
                                 {label}
                             </Typography>
                             <Chip label={ticketsByStatus(key).length} size="small" variant="outlined" />

--- a/SharpClaw/Models/TicketStatus.cs
+++ b/SharpClaw/Models/TicketStatus.cs
@@ -6,6 +6,7 @@ public enum TicketStatus
     Planning,
     Todo,
     InProgress,
+    Blocked,
     ForReview,
     Done
 }
@@ -18,6 +19,7 @@ public static class TicketStatusExtensions
         TicketStatus.Planning => "planning",
         TicketStatus.Todo => "todo",
         TicketStatus.InProgress => "in_progress",
+        TicketStatus.Blocked => "blocked",
         TicketStatus.ForReview => "for_review",
         TicketStatus.Done => "done",
         _ => "idea"
@@ -29,6 +31,7 @@ public static class TicketStatusExtensions
         "planning" => TicketStatus.Planning,
         "todo" => TicketStatus.Todo,
         "in_progress" => TicketStatus.InProgress,
+        "blocked" => TicketStatus.Blocked,
         "for_review" => TicketStatus.ForReview,
         "done" => TicketStatus.Done,
         _ => TicketStatus.Idea

--- a/SharpClaw/Tools/TicketTool.cs
+++ b/SharpClaw/Tools/TicketTool.cs
@@ -16,7 +16,7 @@ public sealed class TicketTool(ProjectLoader loader) : ITool
         new("ticket_id", "string", "Ticket ID (e.g. '001'). Required for get_ticket, update_ticket, move_ticket, delete_ticket.", Required: false),
         new("title", "string", "Ticket title. Required for create_ticket, optional for update_ticket.", Required: false),
         new("description", "string", "Ticket description. Optional for create_ticket and update_ticket.", Required: false),
-        new("status", "string", "Ticket status: idea, planning, todo, in_progress, for_review, done. Optional for update_ticket.", Required: false),
+        new("status", "string", "Ticket status: idea, planning, todo, in_progress, blocked, for_review, done. Optional for update_ticket.", Required: false),
         new("target_project_id", "string", "Target project ID for move_ticket.", Required: false),
     ];
 

--- a/docs/docs/features/projects.md
+++ b/docs/docs/features/projects.md
@@ -81,6 +81,7 @@ The filename (without `.md`) is the **ticket ID** — a zero-padded number like 
 | Planning      | `planning`        | Being scoped and specified         |
 | Todo          | `todo`            | Planned and ready to be picked up  |
 | In Progress   | `in_progress`     | Actively being worked on           |
+| Blocked       | `blocked`         | Cannot progress (external blocker) |
 | For Review    | `for_review`      | Complete, awaiting review          |
 | Done          | `done`            | Finished                           |
 


### PR DESCRIPTION
Closes ticket sharpclaw/021.

## Changes

- **`Models/TicketStatus.cs`** — new `Blocked` enum value between `InProgress` and `ForReview`, plus frontmatter round-trip mappings (`blocked`).
- **`Tools/TicketTool.cs`** — `status` parameter description updated to list `blocked`.
- **`SharpClaw.Web/src/pages/ProjectsPage.tsx`** — Blocked column added to the kanban in the correct position; rendered with a red accent (3px top border + red column header) for visual distinction. Drag/drop works automatically via the existing STATUSES iteration.
- **`docs/docs/features/projects.md`** — status table row added.

The `ProjectTool` summary auto-groups by status so no change needed there. `ProjectLoader` round-trips status via the extension methods, so existing tickets are unaffected.

## Verification

- `dotnet build SharpClaw` — clean
- `npm run build` in `SharpClaw.Web` — clean
- `npm run build` in `docs` — clean