### PR TITLE
Ticket #022: Update ticket-workflow skill for auto-dispatch lifecycle

### DIFF
--- a/SharpClaw/skills/ticket-workflow.skill.md
+++ b/SharpClaw/skills/ticket-workflow.skill.md
@@ -23,29 +23,63 @@ You have two tools for managing work: `project` and `ticket`.
 | `update_ticket` | `project_id`, `ticket_id`, `title`/`description`/`status` (optional) | Update a ticket |
 | `get_ticket` | `project_id`, `ticket_id` | Get full ticket details |
 
-### Ticket Workflow Rules
+### Ticket Statuses
 
-- **Only work on tickets with status `in_progress`**. A human moves tickets to this status when they are ready for you to pick up.
-- Do not start work on tickets in `idea`, `planning`, or `for_review` status.
+| Status | Meaning |
+|--------|---------|
+| `idea` | Captured but not yet refined |
+| `planning` | Being scoped or designed |
+| `todo` | Ready to be picked up. If `assignee` matches a registered agent, the auto-dispatch worker will move it to `in_progress` and invoke that agent. |
+| `in_progress` | Actively being worked on (set by the auto-dispatch worker, or by a human) |
+| `blocked` | Cannot progress without external input; the blocking reason is appended to the description |
+| `for_review` | Work is complete and awaiting human review |
+| `done` | Reviewed and accepted (humans only) |
 
-### Completing Work
+### Two Modes of Working on Tickets
 
-- When you have completed the work described in a ticket, **move it to `for_review`** status.
-- Do not move tickets to `done` — a human will do that after reviewing your work.
+You will encounter tickets in two distinct ways. The rules differ.
 
-### Creating Tickets
+#### Mode A — Auto-dispatched (you were invoked by the worker)
 
-- You may **create new tickets** with status `idea` if asked to by the user.
-- Do not create tickets in any other status.
+When the `TicketAssignmentWorker` picks up a `todo` ticket assigned to you, it moves
+it to `in_progress` and invokes you with a directive containing the ticket details.
+**Treat the conversation prompt as the directive — do the work now.** You only get
+one turn, so you must reach a terminal state before stopping:
+
+- **Complete the work** → append a summary (and PR link, if applicable) to the
+  ticket description, then move it to `for_review`:
+  `ticket(action="update_ticket", project_id="...", ticket_id="...", status="for_review")`
+- **Cannot proceed** (missing info, ambiguity, external dependency, error you
+  cannot resolve) → append a clear explanation of the blocker to the ticket
+  description and move it to `blocked`:
+  `ticket(action="update_ticket", project_id="...", ticket_id="...", status="blocked")`
+
+**Never leave an auto-dispatched ticket in `in_progress`.** Finish or block.
+
+#### Mode B — Interactive (a human is talking to you about a ticket)
+
+The human drives status transitions. You may complete work and move tickets to
+`for_review` if the human explicitly asks, but do not pick tickets up of your own
+accord and do not move them to `in_progress` yourself — the worker (or a human)
+does that.
 
 ### Status Transitions You Are Allowed
 
 | From | To | When |
 |------|----|------|
-| `in_progress` | `for_review` | You completed the work |
+| `in_progress` | `for_review` | You completed the work (either mode) |
+| `in_progress` | `blocked` | Auto-dispatch mode: you cannot proceed; reason appended to description |
 | *(new ticket)* | `idea` | User asked you to create a ticket |
 
 ### Status Transitions You Must NOT Make
 
-- Do not move tickets to `in_progress`, `planning`, or `done`.
-- Do not change the status of tickets that are not `in_progress` (except creating new ones as `idea`).
+- Do **not** move tickets to `in_progress` yourself — only the worker (on a `todo`
+  with a matching assignee) or a human may do this.
+- Do **not** move tickets to `planning` or `done` — those are human-only.
+- Do **not** change the status of unrelated tickets (anything other than the one
+  you are currently working on or being asked about).
+
+### Creating Tickets
+
+- You may **create new tickets** with status `idea` if asked to by the user.
+- Do not create tickets in any other status.


### PR DESCRIPTION
Closes #022.

## Changes
- Rewrote `SharpClaw/skills/ticket-workflow.skill.md` to describe the new `TicketAssignmentWorker` auto-dispatch flow:
  - **Mode A (auto-dispatched)**: treat prompt as directive; finish to `for_review` or block with reason to `blocked`; never leave in `in_progress`.
  - **Mode B (interactive)**: status driven by humans; only complete work to `for_review` when asked.
- Added the full status list including `blocked`.
- Documented allowed transitions `in_progress` → `for_review` and `in_progress` → `blocked`.
- Kept the rule that agents must not move tickets to `in_progress`, `planning`, or `done`.

## Agent audit
All five agents (`ade`, `cody`, `deb`, `fin`, `myles`) already declare both `ticket` and `project` in their `tools` lists — no frontmatter changes needed.

## Verification
- `dotnet build` — 0 errors
- `cd docs && npm run build` — success
- `docs/docs/features/projects.md` already aligns with the new skill text (covers the worker, `blocked`, and the auto-dispatch terminal-state rules).