### PR TITLE
Persist scheduled task results to web transcript

### DIFF
--- a/SharpClaw/Scheduling/WebTaskDelivery.cs
+++ b/SharpClaw/Scheduling/WebTaskDelivery.cs
@@ -1,32 +1,44 @@
+using SharpClaw.Auditing;
+using SharpClaw.Interactions;
 using SharpClaw.Models;
 using SharpClaw.Sessions;
 
 namespace SharpClaw.Scheduling;
 
-public sealed class WebTaskDelivery(AgentSessionRegistry sessionRegistry, ILogger<WebTaskDelivery> logger)
-    : ITaskResultDelivery
+public sealed class WebTaskDelivery(
+    AgentSessionRegistry sessionRegistry,
+    ChannelFanOutService fanOut,
+    TranscriptService transcripts,
+    ILogger<WebTaskDelivery> logger) : ITaskResultDelivery
 {
     public ScheduleChannelType ChannelType => ScheduleChannelType.Web;
 
     public async Task DeliverAsync(ScheduledTask task, string result, CancellationToken ct = default)
     {
-        var session = sessionRegistry.Get(task.AgentId);
-        if (session is null)
-        {
-            logger.LogWarning("No active session for agent '{AgentId}' — task {TaskId} result not delivered",
-                task.AgentId, task.Id);
-            return;
-        }
+        var formatted = $"📋 Scheduled task result ({task.Description ?? task.Id}):\n\n{result}";
 
-        var message = new AgentMessage(
+        var session = sessionRegistry.GetOrCreate(task.AgentId);
+
+        await transcripts.LogAsync(
+            agentName: task.AgentId,
+            sessionId: session.SessionId,
+            turnType: "agent",
+            content: formatted,
+            metadata: new TranscriptMetadata(Source: $"scheduler:{task.Id}"),
+            ct: ct);
+
+        await session.PublishAsync(new AgentMessage(
             session.SessionId,
             Guid.NewGuid().ToString(),
             MessageOrigin.Agent,
             task.AgentId,
-            $"📋 Scheduled task result ({task.Description ?? task.Id}):\n\n{result}",
-            DateTimeOffset.UtcNow);
+            formatted,
+            DateTimeOffset.UtcNow), ct);
 
-        await session.PublishAsync(message, ct);
-        logger.LogDebug("Delivered scheduled task {TaskId} result to web session {SessionId}", task.Id, session.SessionId);
+        await fanOut.BroadcastAsync(task.AgentId, formatted, excludeChannelId: null, ct);
+
+        logger.LogInformation(
+            "Delivered scheduled task {TaskId} result to web (agent {AgentId}, session {SessionId})",
+            task.Id, task.AgentId, session.SessionId);
     }
 }

--- a/docs/docs/features/scheduling.md
+++ b/docs/docs/features/scheduling.md
@@ -15,7 +15,9 @@ The scheduling system allows agents to create one-off or recurring tasks that ex
 5. When a task is due:
    - **Agent tasks**: The agent runs the prompt and delivers the result
    - **Command tasks**: The shell command executes and success/failure is delivered
-6. Results are delivered to the original channel (Telegram or web)
+6. Results are delivered to the original channel:
+   - **Telegram**: sent as a message to the originating chat
+   - **Web**: appended to the agent's transcript (so they appear in chat history when you next open the agent) and broadcast to any open browser tabs in real time
 
 ## Task Types
 


### PR DESCRIPTION
## Problem

Scheduled tasks for web-channel agents (e.g. all of `fin`'s SIPP monitors) were running successfully but no results ever appeared in chat. Loki shows hundreds of:

```
WebTaskDelivery: No active session for agent 'fin' — task ... result not delivered
```

`WebTaskDelivery` was only delivering to a live in-memory `AgentSession` (via `Get`). Once the originating WebSocket disconnected, the session was gone and every scheduled result was silently dropped. Even when a session existed, the delivery wrote to an in-memory `Channel<AgentMessage>` bus that nothing reads from — so it never reached the chat UI either way.

## Fix

`WebTaskDelivery` now:

- Persists the formatted result to the agent's transcript via `TranscriptService`, so it appears in `/api/chat/{agent}/history` next time you open the chat.
- Broadcasts via `ChannelFanOutService` so any open browser tab receives it in real time.
- Uses `GetOrCreate` to ensure a stable session id for the transcript filename.

Docs updated. Build clean.