### PR TITLE
Selectable delivery channel for scheduled tasks + Telegram transcript

### DIFF
--- a/SharpClaw.Web/src/api/tasks.ts
+++ b/SharpClaw.Web/src/api/tasks.ts
@@ -41,6 +41,8 @@ export interface TaskUpdateRequest {
     isOneOff?: boolean;
     agent?: string;
     command?: string;
+    channelType?: string;
+    channelKey?: string;
 }
 
 export interface TaskCreateRequest {
@@ -52,6 +54,8 @@ export interface TaskCreateRequest {
     description?: string;
     isOneOff?: boolean;
     enabled?: boolean;
+    channelType?: string;
+    channelKey?: string;
 }
 
 export const getTasks = () => apiFetch<ScheduledTaskSummary[]>('/tasks');

--- a/SharpClaw.Web/src/pages/TaskCreatePage.tsx
+++ b/SharpClaw.Web/src/pages/TaskCreatePage.tsx
@@ -27,6 +27,8 @@ export default function TaskCreatePage() {
     const [enabled, setEnabled] = useState(true);
     const [isOneOff, setIsOneOff] = useState(false);
     const [prompt, setPrompt] = useState('');
+    const [channelType, setChannelType] = useState<'web' | 'telegram'>('web');
+    const [channelKey, setChannelKey] = useState('');
     const [error, setError] = useState<string | null>(null);
     const [saving, setSaving] = useState(false);
 
@@ -48,6 +50,17 @@ export default function TaskCreatePage() {
             return;
         }
 
+        if (channelType === 'telegram') {
+            if (!channelKey.trim()) {
+                setError('Telegram chat ID is required when delivering to Telegram.');
+                return;
+            }
+            if (!/^-?\d+$/.test(channelKey.trim())) {
+                setError('Telegram chat ID must be a numeric value.');
+                return;
+            }
+        }
+
         try {
             setSaving(true);
             const result = await createTask({
@@ -59,6 +72,8 @@ export default function TaskCreatePage() {
                 description: description.trim() || undefined,
                 isOneOff,
                 enabled,
+                channelType,
+                channelKey: channelType === 'telegram' ? channelKey.trim() : undefined,
             });
             navigate(`/tasks/${result.id}`);
         } catch (e: unknown) {
@@ -163,6 +178,38 @@ export default function TaskCreatePage() {
                             label="One-off (delete after run)"
                         />
                     </Stack>
+
+                    <Box>
+                        <Typography variant="subtitle2" sx={{ mb: 1 }}>Deliver Result To</Typography>
+                        <Stack direction="row" spacing={2} sx={{ alignItems: 'flex-start' }}>
+                            <ToggleButtonGroup
+                                value={channelType}
+                                exclusive
+                                onChange={(_, v) => { if (v) setChannelType(v); }}
+                                size="small"
+                            >
+                                <ToggleButton value="web">Web chat</ToggleButton>
+                                <ToggleButton value="telegram">Telegram</ToggleButton>
+                            </ToggleButtonGroup>
+                            {channelType === 'telegram' && (
+                                <TextField
+                                    label="Chat ID"
+                                    value={channelKey}
+                                    onChange={(e) => setChannelKey(e.target.value)}
+                                    size="small"
+                                    sx={{ width: 200 }}
+                                    placeholder="e.g. 123456789"
+                                    helperText="Must be in Telegram:AllowedChatIds"
+                                    required
+                                />
+                            )}
+                        </Stack>
+                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                            {channelType === 'web'
+                                ? 'Result is appended to the agent\'s chat transcript and broadcast to open browser tabs.'
+                                : 'Result is sent to the specified Telegram chat (and also written to the agent\'s transcript).'}
+                        </Typography>
+                    </Box>
                 </Stack>
             </Paper>
 

--- a/SharpClaw.Web/src/pages/TaskEditorPage.tsx
+++ b/SharpClaw.Web/src/pages/TaskEditorPage.tsx
@@ -8,6 +8,8 @@ import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogActions from '@mui/material/DialogActions';
@@ -33,6 +35,8 @@ export default function TaskEditorPage() {
     const [enabled, setEnabled] = useState(true);
     const [isOneOff, setIsOneOff] = useState(false);
     const [prompt, setPrompt] = useState('');
+    const [channelType, setChannelType] = useState<'web' | 'telegram'>('web');
+    const [channelKey, setChannelKey] = useState('');
     const [error, setError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -50,6 +54,8 @@ export default function TaskEditorPage() {
                 setEnabled(t.enabled);
                 setIsOneOff(t.isOneOff);
                 setPrompt(t.prompt);
+                setChannelType(t.channelType?.toLowerCase() === 'telegram' ? 'telegram' : 'web');
+                setChannelKey(t.channelKey ?? '');
                 setLoading(false);
             })
             .catch(() => {
@@ -62,6 +68,16 @@ export default function TaskEditorPage() {
         try {
             setError(null);
             setSuccess(null);
+            if (channelType === 'telegram') {
+                if (!channelKey.trim()) {
+                    setError('Telegram chat ID is required.');
+                    return;
+                }
+                if (!/^-?\d+$/.test(channelKey.trim())) {
+                    setError('Telegram chat ID must be a numeric value.');
+                    return;
+                }
+            }
             await updateTask(id!, {
                 description,
                 cron,
@@ -70,6 +86,10 @@ export default function TaskEditorPage() {
                 isOneOff,
                 agent,
                 command: task?.taskType === 'command' ? command : undefined,
+                channelType,
+                channelKey: channelType === 'telegram'
+                    ? channelKey.trim()
+                    : `web:${agent || 'system'}`,
             });
             setSuccess('Task saved successfully.');
         } catch (e: unknown) {
@@ -182,10 +202,34 @@ export default function TaskEditorPage() {
                             label="One-off (delete after run)"
                         />
                     </Stack>
+
+                    <Box>
+                        <Typography variant="subtitle2" sx={{ mb: 1 }}>Deliver Result To</Typography>
+                        <Stack direction="row" spacing={2} sx={{ alignItems: 'flex-start' }}>
+                            <ToggleButtonGroup
+                                value={channelType}
+                                exclusive
+                                onChange={(_, v) => { if (v) setChannelType(v); }}
+                                size="small"
+                            >
+                                <ToggleButton value="web">Web chat</ToggleButton>
+                                <ToggleButton value="telegram">Telegram</ToggleButton>
+                            </ToggleButtonGroup>
+                            {channelType === 'telegram' && (
+                                <TextField
+                                    label="Chat ID"
+                                    value={channelKey}
+                                    onChange={(e) => setChannelKey(e.target.value)}
+                                    size="small"
+                                    sx={{ width: 200 }}
+                                    helperText="Must be in Telegram:AllowedChatIds"
+                                    required
+                                />
+                            )}
+                        </Stack>
+                    </Box>
+
                     <Stack direction="row" spacing={3}>
-                        <Typography variant="caption" color="text.secondary">
-                            Channel: {task.channelType} ({task.channelKey})
-                        </Typography>
                         <Typography variant="caption" color="text.secondary">
                             Created: {formatDateTime(task.created)}
                         </Typography>

--- a/SharpClaw/Api/TaskEndpoints.cs
+++ b/SharpClaw/Api/TaskEndpoints.cs
@@ -75,6 +75,13 @@ internal static class TaskEndpoints
             if (taskType == ScheduledTaskType.Agent && string.IsNullOrWhiteSpace(request.Agent))
                 return Results.BadRequest("Agent tasks require an 'agent' field.");
 
+            var channelType = ParseChannelType(request.ChannelType);
+            var channelKey = ResolveChannelKey(channelType, request.ChannelKey, request.Agent);
+            if (channelType == ScheduleChannelType.Telegram && string.IsNullOrWhiteSpace(channelKey))
+                return Results.BadRequest("Telegram channel requires a 'channelKey' (numeric chat ID).");
+            if (channelType == ScheduleChannelType.Telegram && !long.TryParse(channelKey, out _))
+                return Results.BadRequest("Telegram 'channelKey' must be a numeric chat ID.");
+
             var id = Guid.NewGuid().ToString("N")[..12];
             var nextRun = ScheduleStore.ComputeNextRun(request.Cron, DateTimeOffset.UtcNow)
                           ?? DateTimeOffset.UtcNow;
@@ -87,8 +94,8 @@ internal static class TaskEndpoints
                 CronExpression = request.Cron,
                 Description = request.Description ?? string.Empty,
                 IsOneOff = request.IsOneOff ?? false,
-                ChannelKey = $"web:{request.Agent ?? "system"}",
-                ChannelType = ScheduleChannelType.Web,
+                ChannelKey = channelKey!,
+                ChannelType = channelType,
                 TaskType = taskType,
                 Command = taskType == ScheduledTaskType.Command ? request.Command : null,
                 Enabled = request.Enabled ?? true,
@@ -119,6 +126,18 @@ internal static class TaskEndpoints
             var nextRun = ScheduleStore.ComputeNextRun(cronExpr, DateTimeOffset.UtcNow)
                           ?? existing.NextRunUtc;
 
+            var newChannelType = request.ChannelType is null
+                ? existing.ChannelType
+                : ParseChannelType(request.ChannelType);
+            var newAgent = request.Agent ?? existing.AgentId;
+            var newChannelKey = request.ChannelKey
+                ?? (request.ChannelType is null
+                    ? existing.ChannelKey
+                    : ResolveChannelKey(newChannelType, null, newAgent) ?? existing.ChannelKey);
+
+            if (newChannelType == ScheduleChannelType.Telegram && !long.TryParse(newChannelKey, out _))
+                return Results.BadRequest("Telegram 'channelKey' must be a numeric chat ID.");
+
             var updated = existing with
             {
                 Description = request.Description ?? existing.Description,
@@ -126,8 +145,10 @@ internal static class TaskEndpoints
                 Prompt = request.Prompt ?? existing.Prompt,
                 Enabled = request.Enabled ?? existing.Enabled,
                 IsOneOff = request.IsOneOff ?? existing.IsOneOff,
-                AgentId = request.Agent ?? existing.AgentId,
+                AgentId = newAgent,
                 Command = request.Command ?? existing.Command,
+                ChannelType = newChannelType,
+                ChannelKey = newChannelKey,
                 NextRunUtc = nextRun,
             };
 
@@ -141,6 +162,21 @@ internal static class TaskEndpoints
         });
     }
 
+    private static ScheduleChannelType ParseChannelType(string? value) =>
+        string.Equals(value, "telegram", StringComparison.OrdinalIgnoreCase)
+            ? ScheduleChannelType.Telegram
+            : ScheduleChannelType.Web;
+
+    private static string? ResolveChannelKey(ScheduleChannelType type, string? supplied, string? agent)
+    {
+        if (!string.IsNullOrWhiteSpace(supplied))
+            return supplied.Trim();
+
+        return type == ScheduleChannelType.Web
+            ? $"web:{agent ?? "system"}"
+            : null;
+    }
+
 }
 
 internal sealed record TaskCreateRequest(
@@ -151,7 +187,9 @@ internal sealed record TaskCreateRequest(
     string? Prompt,
     string? Description,
     bool? IsOneOff,
-    bool? Enabled
+    bool? Enabled,
+    string? ChannelType,
+    string? ChannelKey
 );
 
 internal sealed record TaskUpdateRequest(
@@ -161,5 +199,7 @@ internal sealed record TaskUpdateRequest(
     bool? Enabled,
     bool? IsOneOff,
     string? Agent,
-    string? Command
+    string? Command,
+    string? ChannelType,
+    string? ChannelKey
 );

--- a/SharpClaw/Scheduling/TelegramTaskDelivery.cs
+++ b/SharpClaw/Scheduling/TelegramTaskDelivery.cs
@@ -1,10 +1,17 @@
+using SharpClaw.Auditing;
+using SharpClaw.Interactions;
 using SharpClaw.Models;
+using SharpClaw.Sessions;
 using Telegram.Bot;
 
 namespace SharpClaw.Scheduling;
 
-public sealed class TelegramTaskDelivery(ITelegramBotClient botClient, ILogger<TelegramTaskDelivery> logger)
-    : ITaskResultDelivery
+public sealed class TelegramTaskDelivery(
+    ITelegramBotClient botClient,
+    AgentSessionRegistry sessionRegistry,
+    ChannelFanOutService fanOut,
+    TranscriptService transcripts,
+    ILogger<TelegramTaskDelivery> logger) : ITaskResultDelivery
 {
     public ScheduleChannelType ChannelType => ScheduleChannelType.Telegram;
 
@@ -16,8 +23,32 @@ public sealed class TelegramTaskDelivery(ITelegramBotClient botClient, ILogger<T
             return;
         }
 
-        var message = $"📋 **Scheduled task result** ({task.Description ?? task.Id}):\n\n{result}";
-        await botClient.SendMessage(chatId, message, cancellationToken: ct);
-        logger.LogDebug("Delivered scheduled task {TaskId} result to Telegram chat {ChatId}", task.Id, chatId);
+        var formatted = $"📋 **Scheduled task result** ({task.Description ?? task.Id}):\n\n{result}";
+
+        await botClient.SendMessage(chatId, formatted, cancellationToken: ct);
+
+        var session = sessionRegistry.GetOrCreate(task.AgentId);
+
+        await transcripts.LogAsync(
+            agentName: task.AgentId,
+            sessionId: session.SessionId,
+            turnType: "agent",
+            content: formatted,
+            metadata: new TranscriptMetadata(Source: $"scheduler:{task.Id}:telegram"),
+            ct: ct);
+
+        await session.PublishAsync(new AgentMessage(
+            session.SessionId,
+            Guid.NewGuid().ToString(),
+            MessageOrigin.Agent,
+            task.AgentId,
+            formatted,
+            DateTimeOffset.UtcNow), ct);
+
+        await fanOut.BroadcastAsync(task.AgentId, formatted, excludeChannelId: null, ct);
+
+        logger.LogInformation(
+            "Delivered scheduled task {TaskId} result to Telegram chat {ChatId} (agent {AgentId})",
+            task.Id, chatId, task.AgentId);
     }
 }

--- a/docs/docs/features/scheduling.md
+++ b/docs/docs/features/scheduling.md
@@ -15,9 +15,18 @@ The scheduling system allows agents to create one-off or recurring tasks that ex
 5. When a task is due:
    - **Agent tasks**: The agent runs the prompt and delivers the result
    - **Command tasks**: The shell command executes and success/failure is delivered
-6. Results are delivered to the original channel:
-   - **Telegram**: sent as a message to the originating chat
-   - **Web**: appended to the agent's transcript (so they appear in chat history when you next open the agent) and broadcast to any open browser tabs in real time
+6. Results are delivered to the channel selected when the task was created:
+   - **Telegram**: sent as a message to the configured chat ID, **and** appended to the agent's transcript so it also shows up in the web UI history
+   - **Web**: appended to the agent's transcript (visible in chat history when you next open the agent) and broadcast live to any open browser tab
+
+## Choosing the Delivery Channel
+
+When you create a task in the web UI you can choose where the result is delivered:
+
+- **Web chat** (default) — result is written to the agent's chat transcript and pushed to any open browser tab in real time. Use this when you want the result to land in the SharpClaw web UI alongside your normal chat history.
+- **Telegram** — result is sent as a Telegram message to the chat ID you provide. The chat ID must be in `Telegram:AllowedChatIds`. The result is also written to the agent's transcript so it remains visible in the web UI.
+
+When tasks are scheduled programmatically via the `schedule_task` tool, the channel is inherited from the originating chat (Telegram chat → Telegram delivery, web chat → web delivery).
 
 ## Task Types
 


### PR DESCRIPTION
## Summary

Two follow-ups to PR #99:

### 1. `TelegramTaskDelivery` now writes to transcript + fans out

Previously, scheduled tasks delivered via Telegram appeared only in Telegram — they weren't written to the agent's transcript, so the web UI never showed them. Now `TelegramTaskDelivery` also calls `TranscriptService.LogAsync` and `ChannelFanOutService.BroadcastAsync`, mirroring `WebTaskDelivery`. Scheduled results show up everywhere the agent is reachable.

### 2. UI delivery-channel selector

The task create/edit pages get a 'Deliver Result To' toggle (Web / Telegram). When Telegram is selected, a Chat ID field appears and is required (numeric, must be in `Telegram:AllowedChatIds`).

Backend:
- `TaskCreateRequest` and `TaskUpdateRequest` accept `channelType` and `channelKey`
- POST defaults to `web` (backwards-compatible) but can be set to `telegram` with a chat ID
- PUT lets you change channel/key on an existing task
- Validation rejects non-numeric Telegram chat IDs

Frontend:
- `TaskCreatePage`: ToggleButtonGroup + conditional Chat ID field
- `TaskEditorPage`: same controls, replacing the read-only 'Channel: …' caption
- `tasks.ts`: types extended

Docs updated. Backend, frontend, and docs builds all clean.