### PR TITLE
Automated backup solution (ticket #009)

### DIFF
--- a/SharpClaw.Tests/BackupServiceTests.cs
+++ b/SharpClaw.Tests/BackupServiceTests.cs
@@ -1,0 +1,146 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SharpClaw.Backup;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Tests;
+
+public sealed class BackupServiceTests
+{
+    [Fact]
+    public async Task RunBackupAsync_creates_tarball_with_sha256_excluding_coding()
+    {
+        var workspace = Path.Combine(Path.GetTempPath(), $"sc-bk-ws-{Guid.NewGuid():N}");
+        var backupRoot = Path.Combine(Path.GetTempPath(), $"sc-bk-out-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workspace);
+        Directory.CreateDirectory(Path.Combine(workspace, "memory"));
+        Directory.CreateDirectory(Path.Combine(workspace, "coding", "junk"));
+        await File.WriteAllTextAsync(Path.Combine(workspace, "memory", "notes.md"), "hello");
+        await File.WriteAllTextAsync(Path.Combine(workspace, "coding", "junk", "huge.bin"), new string('x', 4096));
+
+        try
+        {
+            var svc = new BackupService(
+                Options.Create(new BackupOptions { Enabled = true, RootPath = backupRoot, RetentionDays = 1 }),
+                Options.Create(new SharpClawOptions { WorkspacePath = workspace }),
+                new EmptyServiceProvider(),
+                NullLogger<BackupService>.Instance);
+
+            var result = await svc.RunBackupAsync();
+
+            Assert.True(result.Success, result.Error);
+            Assert.NotNull(result.ArchivePath);
+            Assert.True(File.Exists(result.ArchivePath));
+            Assert.True(File.Exists(result.ArchivePath + ".sha256"));
+            Assert.NotNull(result.Sha256);
+
+            var entries = ListTarEntries(result.ArchivePath!);
+            Assert.Contains("memory/notes.md", entries);
+            Assert.DoesNotContain(entries, e => e.StartsWith("coding/", StringComparison.OrdinalIgnoreCase));
+
+            var logPath = Path.Combine(backupRoot, "backup-log.jsonl");
+            Assert.True(File.Exists(logPath));
+            var logText = await File.ReadAllTextAsync(logPath);
+            Assert.Contains("\"kind\":\"backup\"", logText);
+            Assert.Contains("\"success\":true", logText);
+        }
+        finally
+        {
+            try { Directory.Delete(workspace, true); } catch { }
+            try { Directory.Delete(backupRoot, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task VerifyMode_does_not_leave_files_behind()
+    {
+        var workspace = Path.Combine(Path.GetTempPath(), $"sc-bk-ws-{Guid.NewGuid():N}");
+        var backupRoot = Path.Combine(Path.GetTempPath(), $"sc-bk-out-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workspace);
+        await File.WriteAllTextAsync(Path.Combine(workspace, "a.txt"), "1");
+
+        try
+        {
+            var svc = new BackupService(
+                Options.Create(new BackupOptions { Enabled = true, RootPath = backupRoot }),
+                Options.Create(new SharpClawOptions { WorkspacePath = workspace }),
+                new EmptyServiceProvider(),
+                NullLogger<BackupService>.Instance);
+
+            var result = await svc.RunBackupAsync(dryRun: true);
+
+            Assert.True(result.Success, result.Error);
+            // verify mode should not leave any tarballs in the live root
+            if (Directory.Exists(backupRoot))
+            {
+                Assert.Empty(Directory.GetFiles(backupRoot, "backup-*.tar.gz"));
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(workspace, true); } catch { }
+            try { Directory.Delete(backupRoot, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task RunRetentionAsync_deletes_old_archives()
+    {
+        var workspace = Path.Combine(Path.GetTempPath(), $"sc-bk-ws-{Guid.NewGuid():N}");
+        var backupRoot = Path.Combine(Path.GetTempPath(), $"sc-bk-out-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workspace);
+        Directory.CreateDirectory(backupRoot);
+
+        var oldTar = Path.Combine(backupRoot, "backup-2020-01-01-0300.tar.gz");
+        var oldSha = oldTar + ".sha256";
+        var newTar = Path.Combine(backupRoot, "backup-2999-01-01-0300.tar.gz");
+        await File.WriteAllTextAsync(oldTar, "old");
+        await File.WriteAllTextAsync(oldSha, "deadbeef");
+        await File.WriteAllTextAsync(newTar, "new");
+        File.SetLastWriteTimeUtc(oldTar, DateTime.UtcNow.AddDays(-30));
+        File.SetLastWriteTimeUtc(oldSha, DateTime.UtcNow.AddDays(-30));
+        File.SetLastWriteTimeUtc(newTar, DateTime.UtcNow);
+
+        try
+        {
+            var svc = new BackupService(
+                Options.Create(new BackupOptions { Enabled = true, RootPath = backupRoot, RetentionDays = 7 }),
+                Options.Create(new SharpClawOptions { WorkspacePath = workspace }),
+                new EmptyServiceProvider(),
+                NullLogger<BackupService>.Instance);
+
+            var result = await svc.RunRetentionAsync();
+
+            Assert.True(result.Success);
+            Assert.Equal(2, result.Deleted);
+            Assert.False(File.Exists(oldTar));
+            Assert.False(File.Exists(oldSha));
+            Assert.True(File.Exists(newTar));
+        }
+        finally
+        {
+            try { Directory.Delete(workspace, true); } catch { }
+            try { Directory.Delete(backupRoot, true); } catch { }
+        }
+    }
+
+    private static List<string> ListTarEntries(string tarGzPath)
+    {
+        var names = new List<string>();
+        using var fs = File.OpenRead(tarGzPath);
+        using var gz = new GZipStream(fs, CompressionMode.Decompress);
+        using var reader = new TarReader(gz);
+        while (reader.GetNextEntry() is { } entry)
+        {
+            names.Add(entry.Name);
+        }
+        return names;
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+}

--- a/SharpClaw/Backup/BackupService.cs
+++ b/SharpClaw/Backup/BackupService.cs
@@ -1,0 +1,334 @@
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using SharpClaw.Configuration;
+using Telegram.Bot;
+
+namespace SharpClaw.Backup;
+
+public sealed record BackupResult(
+    bool Success,
+    string? ArchivePath,
+    long ArchiveBytes,
+    string? Sha256,
+    TimeSpan Duration,
+    string? Error,
+    int FilesIncluded);
+
+public sealed record RetentionResult(
+    bool Success,
+    int Deleted,
+    long BytesFreed,
+    IReadOnlyList<string> DeletedFiles,
+    string? Error);
+
+public sealed class BackupService(
+    IOptions<BackupOptions> backupOptions,
+    IOptions<SharpClawOptions> sharpClawOptions,
+    IServiceProvider services,
+    ILogger<BackupService> logger)
+{
+    private readonly BackupOptions _options = backupOptions.Value;
+    private readonly SharpClawOptions _sharpClaw = sharpClawOptions.Value;
+    private readonly IServiceProvider _services = services;
+    private readonly ILogger<BackupService> _logger = logger;
+
+    public async Task<BackupResult> RunBackupAsync(bool dryRun = false, CancellationToken ct = default)
+    {
+        var sw = Stopwatch.StartNew();
+        string? archivePath = null;
+        try
+        {
+            var workspace = ResolveWorkspace();
+            var rootPath = _options.RootPath;
+            Directory.CreateDirectory(rootPath);
+
+            var stamp = DateTime.UtcNow.ToString("yyyy-MM-dd-HHmm");
+            var fileName = $"backup-{stamp}.tar.gz";
+            var targetDir = dryRun
+                ? Path.Combine(Path.GetTempPath(), $"sharpclaw-backup-verify-{Guid.NewGuid():N}")
+                : rootPath;
+            if (dryRun) Directory.CreateDirectory(targetDir);
+            archivePath = Path.Combine(targetDir, fileName);
+
+            var snapshotDir = Path.Combine(Path.GetTempPath(), $"sharpclaw-db-snap-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(snapshotDir);
+
+            var dbSnapshots = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                foreach (var rel in _options.SqliteRelativePaths)
+                {
+                    var src = Path.Combine(workspace, rel);
+                    if (!File.Exists(src)) continue;
+                    var snap = Path.Combine(snapshotDir, Path.GetFileName(rel));
+                    SnapshotSqlite(src, snap);
+                    dbSnapshots[NormalizeRel(rel)] = snap;
+                    _logger.LogInformation("Backup: snapshotted SQLite {Source} -> {Target}", src, snap);
+                }
+
+                var filesIncluded = await WriteArchiveAsync(workspace, archivePath, dbSnapshots, ct);
+
+                var archiveBytes = new FileInfo(archivePath).Length;
+                var sha = ComputeSha256(archivePath);
+                var sidecarPath = archivePath + ".sha256";
+                await File.WriteAllTextAsync(sidecarPath, $"{sha}  {Path.GetFileName(archivePath)}\n", ct);
+
+                sw.Stop();
+                var result = new BackupResult(true, archivePath, archiveBytes, sha, sw.Elapsed, null, filesIncluded);
+                AppendLog(result, dryRun);
+
+                if (dryRun)
+                {
+                    try { File.Delete(archivePath); } catch { }
+                    try { File.Delete(sidecarPath); } catch { }
+                    try { Directory.Delete(targetDir, recursive: true); } catch { }
+                }
+
+                _logger.LogInformation("Backup: success archive={Archive} bytes={Bytes} sha256={Sha} duration={Duration} files={Files} dryRun={DryRun}",
+                    archivePath, archiveBytes, sha, sw.Elapsed, filesIncluded, dryRun);
+                return result;
+            }
+            finally
+            {
+                try { Directory.Delete(snapshotDir, recursive: true); } catch { }
+            }
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            _logger.LogError(ex, "Backup failed after {Duration}", sw.Elapsed);
+            var result = new BackupResult(false, archivePath, 0, null, sw.Elapsed, ex.Message, 0);
+            AppendLog(result, dryRun);
+            await NotifyAsync($"❌ SharpClaw backup FAILED ({(dryRun ? "verify" : "live")})\nError: {ex.Message}\nDuration: {sw.Elapsed:c}", ct);
+            return result;
+        }
+    }
+
+    public async Task<RetentionResult> RunRetentionAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var rootPath = _options.RootPath;
+            if (!Directory.Exists(rootPath))
+                return new RetentionResult(true, 0, 0, Array.Empty<string>(), null);
+
+            var cutoff = DateTime.UtcNow.AddDays(-Math.Max(1, _options.RetentionDays));
+            var deleted = new List<string>();
+            long bytesFreed = 0;
+
+            foreach (var pattern in new[] { "backup-*.tar.gz", "backup-*.tar.gz.sha256" })
+            {
+                foreach (var file in Directory.EnumerateFiles(rootPath, pattern))
+                {
+                    var info = new FileInfo(file);
+                    if (info.LastWriteTimeUtc < cutoff)
+                    {
+                        bytesFreed += info.Length;
+                        info.Delete();
+                        deleted.Add(info.Name);
+                        _logger.LogInformation("Retention: deleted {File} (age {Age:c})", info.Name, DateTime.UtcNow - info.LastWriteTimeUtc);
+                    }
+                }
+            }
+
+            var result = new RetentionResult(true, deleted.Count, bytesFreed, deleted, null);
+            AppendRetentionLog(result);
+            _logger.LogInformation("Retention: deleted {Count} files, freed {Bytes} bytes", deleted.Count, bytesFreed);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Retention failed");
+            var result = new RetentionResult(false, 0, 0, Array.Empty<string>(), ex.Message);
+            AppendRetentionLog(result);
+            await NotifyAsync($"❌ SharpClaw backup retention FAILED\nError: {ex.Message}", ct);
+            return result;
+        }
+    }
+
+    private string ResolveWorkspace()
+    {
+        var ws = _sharpClaw.WorkspacePath;
+        if (string.IsNullOrWhiteSpace(ws))
+            throw new InvalidOperationException("SharpClaw:WorkspacePath is not configured; cannot back up.");
+        if (!Directory.Exists(ws))
+            throw new DirectoryNotFoundException($"Workspace path does not exist: {ws}");
+        return Path.GetFullPath(ws);
+    }
+
+    private static void SnapshotSqlite(string sourceDbPath, string targetDbPath)
+    {
+        using var src = new SqliteConnection($"Data Source={sourceDbPath};Mode=ReadOnly");
+        src.Open();
+        using var dst = new SqliteConnection($"Data Source={targetDbPath}");
+        dst.Open();
+        src.BackupDatabase(dst);
+    }
+
+    private async Task<int> WriteArchiveAsync(string workspace, string archivePath, IDictionary<string, string> dbSnapshots, CancellationToken ct)
+    {
+        var excludes = _options.ExcludeRelativePaths
+            .Select(NormalizeRel)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var snapshotKeys = dbSnapshots.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var filesIncluded = 0;
+
+        await using (var fs = new FileStream(archivePath, FileMode.Create, FileAccess.Write, FileShare.None))
+        await using (var gz = new GZipStream(fs, CompressionLevel.SmallestSize))
+        await using (var tar = new TarWriter(gz, TarEntryFormat.Pax, leaveOpen: false))
+        {
+            foreach (var entry in EnumerateWorkspace(workspace, excludes))
+            {
+                ct.ThrowIfCancellationRequested();
+                var rel = NormalizeRel(Path.GetRelativePath(workspace, entry));
+
+                if (rel.EndsWith(".db-wal", StringComparison.OrdinalIgnoreCase) ||
+                    rel.EndsWith(".db-shm", StringComparison.OrdinalIgnoreCase) ||
+                    rel.EndsWith(".db-journal", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (snapshotKeys.Contains(rel))
+                    continue;
+
+                await tar.WriteEntryAsync(entry, rel, ct);
+                filesIncluded++;
+            }
+
+            foreach (var (rel, snapPath) in dbSnapshots)
+            {
+                ct.ThrowIfCancellationRequested();
+                await tar.WriteEntryAsync(snapPath, rel, ct);
+                filesIncluded++;
+            }
+        }
+
+        return filesIncluded;
+    }
+
+    private static IEnumerable<string> EnumerateWorkspace(string workspace, HashSet<string> excludes)
+    {
+        var stack = new Stack<string>();
+        stack.Push(workspace);
+        while (stack.Count > 0)
+        {
+            var dir = stack.Pop();
+            string[] subDirs;
+            string[] files;
+            try
+            {
+                subDirs = Directory.GetDirectories(dir);
+                files = Directory.GetFiles(dir);
+            }
+            catch (UnauthorizedAccessException) { continue; }
+
+            foreach (var sub in subDirs)
+            {
+                var rel = NormalizeRel(Path.GetRelativePath(workspace, sub));
+                if (IsExcluded(rel, excludes)) continue;
+                stack.Push(sub);
+            }
+            foreach (var f in files)
+            {
+                var rel = NormalizeRel(Path.GetRelativePath(workspace, f));
+                if (IsExcluded(rel, excludes)) continue;
+                yield return f;
+            }
+        }
+    }
+
+    private static bool IsExcluded(string rel, HashSet<string> excludes)
+    {
+        foreach (var ex in excludes)
+        {
+            if (rel.Equals(ex, StringComparison.OrdinalIgnoreCase)) return true;
+            if (rel.StartsWith(ex + "/", StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+
+    private static string NormalizeRel(string rel) => rel.Replace('\\', '/').TrimStart('/');
+
+    private static string ComputeSha256(string path)
+    {
+        using var sha = SHA256.Create();
+        using var fs = File.OpenRead(path);
+        var hash = sha.ComputeHash(fs);
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash) sb.Append(b.ToString("x2"));
+        return sb.ToString();
+    }
+
+    private void AppendLog(BackupResult result, bool dryRun)
+    {
+        try
+        {
+            Directory.CreateDirectory(_options.RootPath);
+            var logPath = Path.Combine(_options.RootPath, "backup-log.jsonl");
+            var entry = new
+            {
+                ts = DateTime.UtcNow,
+                kind = "backup",
+                dryRun,
+                success = result.Success,
+                archive = result.ArchivePath is null ? null : Path.GetFileName(result.ArchivePath),
+                bytes = result.ArchiveBytes,
+                sha256 = result.Sha256,
+                durationMs = (long)result.Duration.TotalMilliseconds,
+                files = result.FilesIncluded,
+                error = result.Error,
+            };
+            File.AppendAllText(logPath, JsonSerializer.Serialize(entry) + "\n");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to append backup log");
+        }
+    }
+
+    private void AppendRetentionLog(RetentionResult result)
+    {
+        try
+        {
+            Directory.CreateDirectory(_options.RootPath);
+            var logPath = Path.Combine(_options.RootPath, "backup-log.jsonl");
+            var entry = new
+            {
+                ts = DateTime.UtcNow,
+                kind = "retention",
+                success = result.Success,
+                deleted = result.Deleted,
+                bytesFreed = result.BytesFreed,
+                files = result.DeletedFiles,
+                error = result.Error,
+            };
+            File.AppendAllText(logPath, JsonSerializer.Serialize(entry) + "\n");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to append retention log");
+        }
+    }
+
+    private async Task NotifyAsync(string message, CancellationToken ct)
+    {
+        var chatId = _options.NotifyTelegramChatId;
+        if (chatId is null) return;
+        var telegram = _services.GetService<ITelegramBotClient>();
+        if (telegram is null) return;
+        try
+        {
+            await telegram.SendMessage(chatId.Value, message, cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send backup failure notification to {ChatId}", chatId);
+        }
+    }
+}

--- a/SharpClaw/Configuration/BackupOptions.cs
+++ b/SharpClaw/Configuration/BackupOptions.cs
@@ -1,0 +1,24 @@
+namespace SharpClaw.Configuration;
+
+public sealed class BackupOptions
+{
+    public const string SectionName = "Backup";
+
+    public bool Enabled { get; set; } = false;
+
+    public string RootPath { get; set; } = "/srv/backups/sharpclaw";
+
+    public string CronExpression { get; set; } = "0 3 * * *";
+
+    public int RetentionDays { get; set; } = 7;
+
+    public long? NotifyTelegramChatId { get; set; }
+
+    public IList<string> ExcludeRelativePaths { get; set; } = new List<string> { "coding" };
+
+    public IList<string> SqliteRelativePaths { get; set; } = new List<string>
+    {
+        "token-usage.db",
+        "data/semantic-memory.db",
+    };
+}

--- a/SharpClaw/Program.cs
+++ b/SharpClaw/Program.cs
@@ -45,6 +45,7 @@ builder.Services.Configure<AnthropicAdminMcpOptions>(builder.Configuration.GetSe
 builder.Services.Configure<SemanticMemoryOptions>(builder.Configuration.GetSection(SemanticMemoryOptions.SectionName));
 builder.Services.Configure<SttOptions>(builder.Configuration.GetSection(SttOptions.SectionName));
 builder.Services.Configure<TicketWorkerOptions>(builder.Configuration.GetSection(TicketWorkerOptions.SectionName));
+builder.Services.Configure<BackupOptions>(builder.Configuration.GetSection(BackupOptions.SectionName));
 
 // -- Logging: Console with custom format --
 builder.Logging.ClearProviders();
@@ -123,6 +124,8 @@ builder.Services.AddSingleton<WorkspaceFileTool>();
 builder.Services.AddSingleton<WorkspaceWriteTool>();
 builder.Services.AddSingleton<ProjectTool>();
 builder.Services.AddSingleton<TicketTool>();
+builder.Services.AddSingleton<SharpClaw.Backup.BackupService>();
+builder.Services.AddSingleton<BackupTool>();
 
 // -- Sessions & Interactions --
 builder.Services.AddSingleton<AgentSessionRegistry>();
@@ -225,6 +228,7 @@ builder.Services.AddSingleton<RegistryWorker>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<RegistryWorker>());
 builder.Services.AddHostedService<SchedulerWorker>();
 builder.Services.AddHostedService<TicketAssignmentWorker>();
+builder.Services.AddHostedService<BackupWorker>();
 builder.Services.AddSingleton<ServiceRunner>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ServiceRunner>());
 
@@ -248,6 +252,7 @@ toolRegistry.Register(app.Services.GetRequiredService<WorkspaceFileTool>());
 toolRegistry.Register(app.Services.GetRequiredService<WorkspaceWriteTool>());
 toolRegistry.Register(app.Services.GetRequiredService<ProjectTool>());
 toolRegistry.Register(app.Services.GetRequiredService<TicketTool>());
+toolRegistry.Register(app.Services.GetRequiredService<BackupTool>());
 
 if (!string.IsNullOrEmpty(telegramToken) && telegramToken != "YOUR_BOT_TOKEN_HERE")
 {

--- a/SharpClaw/Tools/BackupTool.cs
+++ b/SharpClaw/Tools/BackupTool.cs
@@ -1,0 +1,63 @@
+using SharpClaw.Abstractions;
+using SharpClaw.Backup;
+using SharpClaw.Models;
+
+namespace SharpClaw.Tools;
+
+public sealed class BackupTool(BackupService backupService) : ITool
+{
+    public string Name => "run_backup";
+
+    public string Description => "Run a SharpClaw workspace backup on demand. Modes: 'backup' (default) creates a tarball + sha256, 'verify' performs a dry-run that builds and hashes a tarball into a temp dir then deletes it (used for monthly restore-readiness checks), 'retention' prunes archives older than the configured retention window.";
+
+    public IReadOnlyList<ToolParameterDefinition> Parameters { get; } =
+    [
+        new("mode", "string", "One of 'backup', 'verify', or 'retention'. Defaults to 'backup'.", Required: false),
+    ];
+
+    public async Task<object?> ExecuteAsync(ToolCallContext context, CancellationToken ct = default)
+    {
+        var mode = context.GetString("mode");
+        if (string.IsNullOrWhiteSpace(mode)) mode = "backup";
+
+        switch (mode.Trim().ToLowerInvariant())
+        {
+            case "backup":
+            {
+                var r = await backupService.RunBackupAsync(dryRun: false, ct);
+                return r.Success
+                    ? $"✅ Backup complete: {Path.GetFileName(r.ArchivePath)} ({FormatBytes(r.ArchiveBytes)}, {r.FilesIncluded} files, sha256={r.Sha256?[..12]}…, took {r.Duration:c})"
+                    : $"❌ Backup FAILED after {r.Duration:c}: {r.Error}";
+            }
+            case "verify":
+            {
+                var r = await backupService.RunBackupAsync(dryRun: true, ct);
+                return r.Success
+                    ? $"✅ Verify-mode backup OK: would produce {FormatBytes(r.ArchiveBytes)} archive ({r.FilesIncluded} files, sha256={r.Sha256?[..12]}…, took {r.Duration:c}). Temp tarball discarded."
+                    : $"❌ Verify-mode backup FAILED after {r.Duration:c}: {r.Error}";
+            }
+            case "retention":
+            {
+                var r = await backupService.RunRetentionAsync(ct);
+                return r.Success
+                    ? $"✅ Retention complete: deleted {r.Deleted} files ({FormatBytes(r.BytesFreed)} freed)."
+                    : $"❌ Retention FAILED: {r.Error}";
+            }
+            default:
+                return $"Error: unknown mode '{mode}'. Expected 'backup', 'verify', or 'retention'.";
+        }
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        double value = bytes;
+        var unit = 0;
+        while (value >= 1024 && unit < units.Length - 1)
+        {
+            value /= 1024;
+            unit++;
+        }
+        return $"{value:0.##} {units[unit]}";
+    }
+}

--- a/SharpClaw/Workers/BackupWorker.cs
+++ b/SharpClaw/Workers/BackupWorker.cs
@@ -1,0 +1,69 @@
+using Cronos;
+using Microsoft.Extensions.Options;
+using SharpClaw.Backup;
+using SharpClaw.Configuration;
+
+namespace SharpClaw.Workers;
+
+public sealed class BackupWorker(
+    BackupService backupService,
+    IOptions<BackupOptions> options,
+    ILogger<BackupWorker> logger) : BackgroundService
+{
+    private readonly BackupService _backup = backupService;
+    private readonly BackupOptions _options = options.Value;
+    private readonly ILogger<BackupWorker> _logger = logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("BackupWorker disabled (Backup:Enabled=false)");
+            return;
+        }
+
+        CronExpression cron;
+        try
+        {
+            cron = CronExpression.Parse(_options.CronExpression, CronFormat.Standard);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "BackupWorker: invalid cron '{Cron}', worker disabled", _options.CronExpression);
+            return;
+        }
+
+        _logger.LogInformation("BackupWorker started: cron={Cron} root={Root} retentionDays={Days}",
+            _options.CronExpression, _options.RootPath, _options.RetentionDays);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var now = DateTime.UtcNow;
+            var next = cron.GetNextOccurrence(now, inclusive: false);
+            if (next is null)
+            {
+                _logger.LogWarning("BackupWorker: no next occurrence for cron, exiting");
+                return;
+            }
+
+            var delay = next.Value - now;
+            _logger.LogInformation("BackupWorker: next run at {Next:O} (in {Delay:c})", next.Value, delay);
+
+            try
+            {
+                await Task.Delay(delay, stoppingToken);
+            }
+            catch (TaskCanceledException) { return; }
+
+            try
+            {
+                await _backup.RunBackupAsync(dryRun: false, stoppingToken);
+                await _backup.RunRetentionAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "BackupWorker: scheduled run failed");
+            }
+        }
+    }
+}

--- a/SharpClaw/appsettings.json
+++ b/SharpClaw/appsettings.json
@@ -58,5 +58,14 @@
   "TicketWorker": {
     "Enabled": true,
     "PollingIntervalSeconds": 60
+  },
+  "Backup": {
+    "Enabled": false,
+    "RootPath": "/srv/backups/sharpclaw",
+    "CronExpression": "0 3 * * *",
+    "RetentionDays": 7,
+    "NotifyTelegramChatId": null,
+    "ExcludeRelativePaths": [ "coding" ],
+    "SqliteRelativePaths": [ "token-usage.db", "data/semantic-memory.db" ]
   }
 }

--- a/docs/docs/features/backup.md
+++ b/docs/docs/features/backup.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 18
+---
+
+# Backup & Disaster Recovery
+
+SharpClaw includes an automated backup feature that produces a daily compressed snapshot of the workspace, plus a disaster-recovery procedure for restoring from one of those snapshots.
+
+## What gets backed up
+
+The backup contains everything under `SharpClaw:WorkspacePath` **except** any path listed in `Backup:ExcludeRelativePaths`. The default exclude is `coding/` (third-party project clones — recoverable from their own remotes).
+
+SQLite databases listed in `Backup:SqliteRelativePaths` are not copied raw (which would risk capturing an inconsistent state mid-write). Instead, each one is copied via SQLite's online backup API (`SqliteConnection.BackupDatabase`) into a temp file and the temp file is added to the archive at the original relative path. WAL/SHM/journal sidecars are skipped.
+
+Defaults:
+
+```jsonc
+{
+  "Backup": {
+    "Enabled": false,                              // off in the shipped appsettings.json
+    "RootPath": "/srv/backups/sharpclaw",          // archives live here
+    "CronExpression": "0 3 * * *",                 // 03:00 UTC daily
+    "RetentionDays": 7,                            // older archives pruned
+    "NotifyTelegramChatId": null,                  // chat to ping on failure
+    "ExcludeRelativePaths": [ "coding" ],
+    "SqliteRelativePaths": [ "token-usage.db", "data/semantic-memory.db" ]
+  }
+}
+```
+
+## Output
+
+Each successful run drops two files into `RootPath`:
+
+```
+backup-YYYY-MM-DD-HHmm.tar.gz
+backup-YYYY-MM-DD-HHmm.tar.gz.sha256
+```
+
+…and appends a JSON line to `RootPath/backup-log.jsonl` with the timestamp, archive size, sha256, file count, and duration. Retention runs append a line of `kind=retention` after each backup.
+
+Failures are logged at error level **and** sent as a Telegram message to `NotifyTelegramChatId` if configured. The bot must already be a member of that chat/channel.
+
+## Triggers
+
+There are two ways to run a backup:
+
+1. **Scheduled** — `BackupWorker` (a `BackgroundService`) wakes on the configured cron and runs backup → retention back-to-back. Enabled implicitly when `Backup:Enabled=true`.
+2. **On demand** — the `run_backup` tool, registered globally:
+   - `mode=backup` (default) — produce a real archive.
+   - `mode=verify` — dry-run that builds the full tarball into a temp directory, hashes it, then deletes it. Use this to sanity-check that the workspace is backup-able without filling up `RootPath`.
+   - `mode=retention` — prune old archives only.
+
+Any agent with the tool available (any agent with `tools: null` or with `run_backup` listed) can invoke it.
+
+## Filesystem permissions
+
+`RootPath` must be writeable by the SharpClaw process. The default `/srv/backups/sharpclaw` is system-owned, so the one-time setup is:
+
+```bash
+sudo mkdir -p /srv/backups/sharpclaw
+sudo chown $USER:$USER /srv/backups/sharpclaw
+sudo chmod 750 /srv/backups/sharpclaw
+```
+
+For a personal install, `~/sharpclaw-backups` works just as well — point `Backup:RootPath` at it.
+
+## Off-site copy
+
+The shipped backup writes to local disk. To get an off-site copy, configure your remote machine to `scp`/`rsync` pull the archives out of `RootPath` on its own schedule (separate from SharpClaw). The sha256 sidecars let the remote verify integrity without trusting transport. This keeps SharpClaw out of the remote-credential business.
+
+## Disaster recovery
+
+To restore the workspace from a backup:
+
+1. **Stop SharpClaw**:
+   ```bash
+   systemctl --user stop sharpclaw    # or however the service is run
+   ```
+2. **Verify the archive**:
+   ```bash
+   cd /srv/backups/sharpclaw
+   sha256sum -c backup-2026-06-18-0300.tar.gz.sha256
+   ```
+3. **Move aside the existing workspace** (don't delete it until restore is verified):
+   ```bash
+   mv /home/khughes/sharpclaw-workspace /home/khughes/sharpclaw-workspace.broken
+   mkdir /home/khughes/sharpclaw-workspace
+   ```
+4. **Extract** into the empty workspace path:
+   ```bash
+   tar -xzf backup-2026-06-18-0300.tar.gz -C /home/khughes/sharpclaw-workspace
+   ```
+5. **Re-attach `coding/`**: if any project clones from `coding/` are needed, re-clone them from their git remotes. They are intentionally excluded from backups.
+6. **Start SharpClaw** and smoke-test:
+   ```bash
+   systemctl --user start sharpclaw
+   curl http://localhost:5100/health
+   ```
+   Then send a message to one agent and confirm:
+   - prior transcript history is visible in the web UI
+   - `semantic_memory_count` returns a non-zero count
+   - any scheduled tasks listed via `/api/tasks` still appear
+
+If the smoke test passes, delete `sharpclaw-workspace.broken`. If anything is wrong, swap directories back and try an older archive.
+
+## Periodic restore drill
+
+Once a month, run a non-destructive verification:
+
+```bash
+# from any agent with the tool
+run_backup mode=verify
+```
+
+This produces and hashes a full archive in a temp directory, then deletes it. A passing verify means the workspace is internally consistent (notably: the SQLite snapshots succeed) and the cron path is exercising the same code as a live backup.
+
+For a true end-to-end restore drill, copy the latest archive to a scratch directory and extract it there:
+
+```bash
+mkdir /tmp/sc-restore-test
+tar -xzf /srv/backups/sharpclaw/backup-*.tar.gz -C /tmp/sc-restore-test
+ls /tmp/sc-restore-test    # should look like the workspace minus coding/
+sqlite3 /tmp/sc-restore-test/data/semantic-memory.db "SELECT COUNT(*) FROM memories;"
+rm -rf /tmp/sc-restore-test
+```
+
+## Troubleshooting
+
+- **No archives appearing**: confirm `Backup:Enabled=true`, the cron expression is valid (5-field standard cron, UTC), and `BackupWorker started` appears in the logs at startup.
+- **`UnauthorizedAccessException`**: `RootPath` isn't writeable by the SharpClaw user. Fix permissions.
+- **`Workspace path does not exist`**: `SharpClaw:WorkspacePath` is unset or wrong. Backups have nothing to capture without it.
+- **Telegram failure messages not arriving**: the bot must be a member of the chat referenced by `NotifyTelegramChatId`. Note this is checked separately from `Telegram:AllowedChatIds`, which only governs the `send_telegram` tool.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -24,6 +24,7 @@ const sidebars: SidebarsConfig = {
         'features/auditing',
         'features/logging',
         'features/stt',
+        'features/backup',
       ],
     },
   ],


### PR DESCRIPTION
Implements ticket #009.

## What

Daily compressed snapshot of the SharpClaw workspace, plus on-demand and verify modes.

- `BackupService` — tars the workspace under `SharpClaw:WorkspacePath`, excluding `coding/` by default. SQLite DBs (`token-usage.db`, `data/semantic-memory.db`) are snapshotted via the online backup API for consistency, then added to the archive at their original relative paths (raw .db / WAL / SHM are skipped).
- Output: `backup-YYYY-MM-DD-HHmm.tar.gz` + `.sha256` sidecar in `Backup:RootPath` (default `/srv/backups/sharpclaw`), and an append-only `backup-log.jsonl` for both backup and retention runs.
- `BackupWorker` (BackgroundService) runs on a cron (default `0 3 * * *` UTC) and chains backup → retention.
- Retention deletes archives + sidecars older than `RetentionDays` (default 7).
- `run_backup` ITool with modes `backup` | `verify` (dry-run, used for the monthly readiness check — produces a real archive into a temp dir, hashes it, then deletes it) | `retention`.
- Failure notification: Telegram message to `NotifyTelegramChatId` (set to **-1004450843341** per Ken's instruction in the ticket). Independent of the `send_telegram` allowlist — that allowlist only governs tool-initiated sends.
- Disabled by default in `appsettings.json`. Enabled in `appsettings.Development.json`.

## Tests

`BackupServiceTests` (3, all passing):
1. Real archive: contains `memory/notes.md`, excludes anything under `coding/`, writes sha256 sidecar, appends `kind=backup` log line.
2. Verify mode leaves no tarballs in `RootPath`.
3. Retention deletes archives + sha256 sidecars older than the cutoff.

`dotnet build` clean, `dotnet test` passes (the pre-existing `PingCommand` case-sensitivity failure is unrelated).

## Docs

`docs/docs/features/backup.md` — config reference, cron defaults, **full disaster-recovery walkthrough** (stop service → verify sha256 → swap workspace dir aside → extract → smoke test → confirm semantic memory + scheduled tasks), monthly restore-drill procedure, troubleshooting. Added to sidebar. `npm run build` passes.

## Out of scope (per Ken's ticket update)

- Remote SCP pull — Ken to wire up separately, the sha256 sidecars make verification easy.
- Live full-system restore drill — destructive, must run in a maintenance window with human supervision; the doc walkthrough is the runbook.
- 7-day / monthly elapsed-time acceptance criteria — observable only over real time. The cron + log + Telegram failure path is the mechanism that produces the evidence.